### PR TITLE
strip off "chr" on seqnames if exist

### DIFF
--- a/R/annotationFunctions.R
+++ b/R/annotationFunctions.R
@@ -53,6 +53,9 @@ prepareAnnotationsFromGTF <- function(file){
   }else{
     data <- read.delim(file,header=FALSE,comment.char='#')
     colnames(data) <- c("seqname","source","type","start","end","score","strand","frame","attribute")
+    if (startsWith(data$seqname,"chr")){
+      data$seqname = gsub('chr(.*?)','\\1',data$seqname)
+    }
     data <- data[data$type=='exon',]
     data$strand[data$strand=='.'] <- '*'
     data$GENEID = gsub('gene_id (.*?);.*','\\1',data$attribute)


### PR DESCRIPTION
I have compared between the working gtf file and the not working one, and it seems like the one that's not working has "chr" before the chromosome number. I have run using this updated function on RStudio without errors:
![Screen Shot 2020-06-16 at 5 07 24 PM](https://user-images.githubusercontent.com/41866052/84755131-de513880-aff3-11ea-8649-a145fb8f7e6d.png)
