### PR TITLE
Fixed bugs when running extend annotations

### DIFF
--- a/R/isore.R
+++ b/R/isore.R
@@ -437,24 +437,26 @@ isore.extendAnnotations <- function(se,
                                                               fragmentStarts=rowData(seFilteredSpliced)$intronStarts,
                                                               fragmentEnds=rowData(seFilteredSpliced)$intronEnds,
                                                               strand=rowData(seFilteredSpliced)$strand)
-
+      
       names(intronsByReadClass) <- 1:length(intronsByReadClass)
       seqlevels(intronsByReadClass) <-  unique(c(seqlevels(intronsByReadClass), seqlevels(annotationGrangesList)))
 
       exonEndsShifted <-paste(rowData(seFilteredSpliced)$intronStarts,
-                              rowData(seFilteredSpliced)$end + 1,
+                              as.integer(rowData(seFilteredSpliced)$end + 1),
                               sep=',')
-      exonStartsShifted <- paste(rowData(seFilteredSpliced)$start - 1,
+      exonStartsShifted <- paste(as.integer(rowData(seFilteredSpliced)$start - 1),
                                  rowData(seFilteredSpliced)$intronEnds,
                                  sep=',')
-
+      
       exonsByReadClass <- makeGRangesListFromFeatureFragments(seqnames=rowData(seFilteredSpliced)$chr,
                                                               fragmentStarts=exonStartsShifted,
                                                               fragmentEnds=exonEndsShifted,
                                                               strand=rowData(seFilteredSpliced)$strand)
+     
       exonsByReadClass <- narrow(exonsByReadClass, start = 2, end = -2)  # correct junction to exon differences in coordinates
+      
       names(exonsByReadClass) <- 1:length(exonsByReadClass)
-
+      
       # add exon start and exon end rank
       unlistData <- unlist(exonsByReadClass, use.names = FALSE)
       partitioning <- PartitioningByEnd(cumsum(elementNROWS(exonsByReadClass)), names=NULL)


### PR DESCRIPTION
Fixed errors when coincidently the shifted start/end position is an integer that can be nicely represented scientifically and can not be recognized by makeGRangesListFromFeatureFragments function