### PR TITLE
enable the use of customised names to write bambu output to file

### DIFF
--- a/R/constructReadClassTables.R
+++ b/R/constructReadClassTables.R
@@ -112,6 +112,7 @@ constructSplicedReadClassTables <- function(uniqueJunctions, unlisted_junctions,
   
   mcols(exonsByReadClass) <- readTable
  # seqlevels(exonsByReadClass) <- seqLevelList
+  options(scipen = 0)
   return(exonsByReadClass)
 }
 

--- a/R/readWrite.R
+++ b/R/readWrite.R
@@ -11,7 +11,7 @@
 #' package = "bambu"))
 #' path <- tempdir()
 #' writeBambuOutput(se,path)
-writeBambuOutput <- function(se,path){
+writeBambuOutput <- function(se, path, prefix=''){
   if (missing(se) | missing(path)){
     stop('Both summarizedExperiment object from bambu and the path for the output files are required.')
   }else{
@@ -20,17 +20,17 @@ writeBambuOutput <- function(se,path){
       dir.create(outdir, recursive = TRUE)
     }
     transcript_grList <- rowRanges(se)
-    transcript_gtffn <- paste(path,"transcript_exon.gtf",sep="")
+    transcript_gtffn <- paste(outdir, prefix, "extended_annotations.gtf",sep="")
     gtf <- writeToGTF(annotation=transcript_grList,file=transcript_gtffn)
     transcript_counts <- as.data.frame(assays(se)$counts)
     geneIDs <- data.frame(mcols(transcript_grList, use.names=FALSE)$TXNAME,mcols(transcript_grList, use.names=FALSE)$GENEID)
     colnames(geneIDs) <- c("TXNAME","GENEID")
     transcript_counts <- cbind(geneIDs,transcript_counts)  
-    transcript_countsfn <- paste(path,"counts_transcript.txt",sep="")
+    transcript_countsfn <- paste(outdir,prefix, "counts_transcript.txt",sep="")
     write.table(transcript_counts, file= transcript_countsfn, sep="\t",quote=FALSE,row.names= FALSE)
     gene_se <- transcriptToGeneExpression(se)
     gene_counts <- as.data.frame(assays(gene_se)$counts)
-    gene_countsfn <- paste(path,"counts_gene.txt",sep="")
+    gene_countsfn <- paste(outdir, prefix, "counts_gene.txt",sep="")
     write.table(gene_counts, file= gene_countsfn, sep="\t", quote=FALSE)
   }
 }


### PR DESCRIPTION
I added the option to use a custom name prefix when writing results to files. This change might affect how bambu is used in pipelines.