### PR TITLE
Changes to improve code stability

### DIFF
--- a/R/bambu-processReads_utilityJunctionErrorCorrection.R
+++ b/R/bambu-processReads_utilityJunctionErrorCorrection.R
@@ -153,14 +153,19 @@ predictSpliceJunctions <- function(annotatedJunctions, junctionModel=NULL,
     spliceVec <- c("Start","End")
     ## if needed this can be a single function
     metadataList <- lapply(spliceVec, function(splice){
-        annotatedJunctionsTmp <- 
-            GRanges(seqnames = seqnames(annotatedJunctions),
-            ranges = IRanges(start = get(tolower(splice))(annotatedJunctions),
-            end = get(tolower(splice))(annotatedJunctions)), strand = '*')
-        mcols(annotatedJunctionsTmp) <- mcols(annotatedJunctions)
         if (splice == "Start") {
+            annotatedJunctionsTmp <- 
+            GRanges(seqnames = seqnames(annotatedJunctions),
+            ranges = IRanges(start = GRanges::start(annotatedJunctions),
+            end = GRanges::start(annotatedJunctions)), strand = '*')
+            mcols(annotatedJunctionsTmp) <- mcols(annotatedJunctions)
             annotatedJunctionsTmp <- unique(annotatedJunctionsTmp)
-        }else{
+        } else {
+            annotatedJunctionsTmp <- 
+            GRanges(seqnames = seqnames(annotatedJunctions),
+            ranges = IRanges(start = GRanges::end(annotatedJunctions),
+            end = GRanges::end(annotatedJunctions)), strand = '*')
+            mcols(annotatedJunctionsTmp) <- mcols(annotatedJunctions)
             annotatedJunctionsTmp <- sort(unique(annotatedJunctionsTmp))
         }
         return(createSpliceMetadata(annotatedJunctionsTmp, splice))})

--- a/R/bambu-processReads_utilityJunctionErrorCorrection.R
+++ b/R/bambu-processReads_utilityJunctionErrorCorrection.R
@@ -156,15 +156,15 @@ predictSpliceJunctions <- function(annotatedJunctions, junctionModel=NULL,
         if (splice == "Start") {
             annotatedJunctionsTmp <- 
             GRanges(seqnames = seqnames(annotatedJunctions),
-            ranges = IRanges(start = GRanges::start(annotatedJunctions),
-            end = GRanges::start(annotatedJunctions)), strand = '*')
+            ranges = IRanges(start = GenomicRanges::start(annotatedJunctions),
+            end = GenomicRanges::start(annotatedJunctions)), strand = '*')
             mcols(annotatedJunctionsTmp) <- mcols(annotatedJunctions)
             annotatedJunctionsTmp <- unique(annotatedJunctionsTmp)
         } else {
             annotatedJunctionsTmp <- 
             GRanges(seqnames = seqnames(annotatedJunctions),
-            ranges = IRanges(start = GRanges::end(annotatedJunctions),
-            end = GRanges::end(annotatedJunctions)), strand = '*')
+            ranges = IRanges(start = GenomicRanges::end(annotatedJunctions),
+            end = GenomicRanges::end(annotatedJunctions)), strand = '*')
             mcols(annotatedJunctionsTmp) <- mcols(annotatedJunctions)
             annotatedJunctionsTmp <- sort(unique(annotatedJunctionsTmp))
         }


### PR DESCRIPTION
Some fixes to make the code base more stable. The first change is to remove the use of get() which looks into environment variables (prone to crashes if a variable of the same name exists) and directly references the functions that should be used instead. Changes are in bambu-processReads_utilityJunctionErrorCorrection.R