### PR TITLE
noAnno_patch

### DIFF
--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -298,7 +298,7 @@ makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
             rr <- rowData(newUnsplicedSe[intersect(rownames(newUnsplicedSe), 
                                                    newUnsplicedTibble$row_id)])
             rr <- as_tibble(rr) %>% select(confidenceType,
-                                           readCount, geneReadProp, txScore, txFDR, geneScore, geneFDR) %>%
+                                           readCount, geneReadProp, txScore, txNDR, geneScore, geneNDR) %>%
                 mutate(row_id = rownames(rr))
             return(rr)
         } , BPPARAM = bpParameters))

--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -125,16 +125,11 @@ updateStartEndReadCount <- function(combinedFeatureTibble){
 combineFeatureTibble <- function(combinedFeatureTibble,
                                  featureTibbleSummarised, index=1, intraGroup = TRUE){ 
     if (is.null(combinedFeatureTibble)) { 
-        print(featureTibbleSummarised)
         combinedTable <- featureTibbleSummarised %>% 
             select(intronStarts, intronEnds, chr, strand, equal, maxTxScore, NSampleReadCount,
                    NSampleReadProp,NSampleGeneScore,NSampleTxScore, starts_with('start'),
                    starts_with('end'), starts_with('readCount'))
     } else { 
-        print(full_join(combinedFeatureTibble, 
-                                  featureTibbleSummarised, by = c('intronStarts',
-                                                                  'intronEnds', 'chr', 'strand'),
-                                  suffix=c('.combined','.new')))
         combinedTable = full_join(combinedFeatureTibble, 
                                   featureTibbleSummarised, by = c('intronStarts',
                                                                   'intronEnds', 'chr', 'strand'),

--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -12,17 +12,17 @@
 #' @noRd
 isore.combineTranscriptCandidates <- function(readClassList,
                                               stranded, ## stranded used for unspliced reduce  
-                                              min.readCount , min.readFractionByGene , max.geneFDR,
-                                              max.txFDR.multiExon, max.txFDR.singleExon, bpParameters ,verbose){
+                                              min.readCount , min.readFractionByGene , min.geneScore,
+                                              min.txScore.multiExon, min.txScore.singleExon, bpParameters ,verbose){
     combinedSplicedTranscripts <- 
         combineSplicedTranscriptModels(readClassList, bpParameters, 
-                                       min.readCount, min.readFractionByGene, max.geneFDR, 
-                                       max.txFDR.multiExon, max.txFDR.singleExon, verbose) %>% data.table()
+                                       min.readCount, min.readFractionByGene, min.geneScore, 
+                                       min.txScore.multiExon, min.txScore.singleExon, verbose) %>% data.table()
     combinedSplicedTranscripts[,confidenceType := "highConfidenceJunctionReads"]
     combinedUnsplicedTranscripts <- 
         combineUnsplicedTranscriptModels(readClassList, bpParameters, 
-                                         stranded, min.readCount, min.readFractionByGene, max.geneFDR, 
-                                         max.txFDR.multiExon, max.txFDR.singleExon, verbose) %>% data.table()
+                                         stranded, min.readCount, min.readFractionByGene, min.geneScore, 
+                                         min.txScore.multiExon, min.txScore.singleExon, verbose) %>% data.table()
     combinedUnsplicedTranscripts[, confidenceType := "unsplicedNew"]
     combinedTranscripts <- as_tibble(rbindlist(list(combinedSplicedTranscripts,
                                                     combinedUnsplicedTranscripts), fill = TRUE))
@@ -33,8 +33,8 @@ isore.combineTranscriptCandidates <- function(readClassList,
 #' combine spliced transcript models
 #' @noRd
 combineSplicedTranscriptModels <- function(readClassList, bpParameters, 
-                                           min.readCount, min.readFractionByGene , max.geneFDR, 
-                                           max.txFDR.multiExon, max.txFDR.singleExon,
+                                           min.readCount, min.readFractionByGene, min.geneScore, 
+                                           min.txScore.multiExon, min.txScore.singleExon,
                                            verbose){
     options(scipen = 999) #maintain numeric basepair locations not sci.notfi.
     start.ptm <- proc.time()
@@ -49,9 +49,9 @@ combineSplicedTranscriptModels <- function(readClassList, bpParameters,
                                               indexVec, intraGroup = TRUE, 
                                               min.readCount = min.readCount, 
                                               min.readFractionByGene = min.readFractionByGene, 
-                                              max.geneFDR = max.geneFDR, 
-                                              max.txFDR.multiExon = max.txFDR.multiExon,
-                                              max.txFDR.singleExon = max.txFDR.singleExon))
+                                              min.geneScore = min.geneScore, 
+                                              min.txScore.multiExon = min.txScore.multiExon,
+                                              min.txScore.singleExon = min.txScore.singleExon))
     }, BPPARAM = bpParameters)
     combinedFeatureTibble <- 
         sequentialCombineFeatureTibble(combinedFeatureTibbleList, 
@@ -66,8 +66,8 @@ combineSplicedTranscriptModels <- function(readClassList, bpParameters,
 #' Sequentially combine feature tibbles 
 #' @noRd
 sequentialCombineFeatureTibble <- function(readClassList,
-                                           indexList,intraGroup,min.readCount,min.readFractionByGene, max.geneFDR,
-                                           max.txFDR.multiExon, max.txFDR.singleExon){
+                                           indexList,intraGroup,min.readCount,min.readFractionByGene, min.geneScore,
+                                           min.txScore.multiExon, min.txScore.singleExon){
     combinedFeatureTibble <- NULL
     for (s in seq_along(readClassList)){
         combinedListNew <- readClassList[[s]]
@@ -76,9 +76,9 @@ sequentialCombineFeatureTibble <- function(readClassList,
                 extractFeaturesFromReadClassSE(readClassSe = combinedListNew,
                                                sample_id = indexList[s], min.readCount = min.readCount,
                                                min.readFractionByGene = min.readFractionByGene,
-                                               max.geneFDR = max.geneFDR,
-                                               max.txFDR.multiExon = max.txFDR.multiExon,
-                                               max.txFDR.singleExon = max.txFDR.singleExon)
+                                               min.geneScore = min.geneScore,
+                                               min.txScore.multiExon = min.txScore.multiExon,
+                                               min.txScore.singleExon = min.txScore.singleExon)
         }
         combinedFeatureTibble <- combineFeatureTibble(combinedFeatureTibble,
                                                       combinedListNew, index = indexList[s], intraGroup)
@@ -111,7 +111,7 @@ updateStartEndReadCount <- function(combinedFeatureTibble){
     
     combinedFeatureTibble <- combinedFeatureTibble %>% 
         dplyr::select(intronStarts, intronEnds, chr, strand, NSampleReadCount, 
-                      NSampleReadProp, NSampleGeneFDR, NSampleTxFDR, rowID) %>%
+                      NSampleReadProp, NSampleGeneScore, NSampleTxScore, rowID) %>%
         full_join(select(startTibble, rowID, start), by = "rowID") %>% 
         full_join(select(endTibble, rowID, end, readCount=sumReadCount), by = "rowID") %>%
         select(-rowID)
@@ -127,7 +127,7 @@ combineFeatureTibble <- function(combinedFeatureTibble,
     if (is.null(combinedFeatureTibble)) { 
         combinedTable <- featureTibbleSummarised %>% 
             select(intronStarts, intronEnds, chr, strand,NSampleReadCount,
-                   NSampleReadProp,NSampleGeneFDR,NSampleTxFDR, starts_with('start'),
+                   NSampleReadProp,NSampleGeneScore,NSampleTxScore, starts_with('start'),
                    starts_with('end'), starts_with('readCount'))
     } else { 
         combinedTable = full_join(combinedFeatureTibble, 
@@ -138,12 +138,12 @@ combineFeatureTibble <- function(combinedFeatureTibble,
                        pmax0NA(NSampleReadCount.new), 
                    NSampleReadProp = pmax0NA(NSampleReadProp.combined) + 
                        pmax0NA(NSampleReadProp.new), 
-                   NSampleGeneFDR = pmax0NA(NSampleGeneFDR.combined) + 
-                       pmax0NA(NSampleGeneFDR.new), 
-                   NSampleTxFDR = pmax0NA(NSampleTxFDR.combined) + 
-                       pmax0NA(NSampleTxFDR.new)) %>% 
+                   NSampleGeneScore = pmax0NA(NSampleGeneScore.combined) + 
+                       pmax0NA(NSampleGeneScore.new), 
+                   NSampleTxScore = pmax0NA(NSampleTxScore.combined) + 
+                       pmax0NA(NSampleTxScore.new)) %>% 
             select(intronStarts, intronEnds, chr, strand, NSampleReadCount, 
-                   NSampleReadProp, NSampleGeneFDR, NSampleTxFDR, starts_with('start'),
+                   NSampleReadProp, NSampleGeneScore, NSampleTxScore, starts_with('start'),
                    starts_with('end'), starts_with('readCount')) 
     } 
     if(intraGroup) 
@@ -168,7 +168,7 @@ pmin0NA <- function(vec){
 #' @noRd
 extractFeaturesFromReadClassSE <- function(readClassSe, sample_id,
                                            min.readCount, min.readFractionByGene, 
-                                           max.geneFDR, max.txFDR.multiExon, max.txFDR.singleExon){
+                                           min.geneScore, min.txScore.multiExon, min.txScore.singleExon){
     if (is.character(readClassSe)) 
         readClassSe <- readRDS(file = readClassSe)
     dimNames <- list(rownames(readClassSe), colnames(readClassSe))
@@ -178,21 +178,21 @@ extractFeaturesFromReadClassSE <- function(readClassSe, sample_id,
                end= unname(max(end(rowRangesSe))))
     group_var <- c("intronStarts", "intronEnds", "chr", "strand")
     sum_var <- c("start","end","NSampleReadCount",
-                 "readCount","NSampleReadProp","NSampleGeneFDR","NSampleTxFDR")
+                 "readCount","NSampleReadProp","NSampleGeneScore","NSampleTxScore")
     featureTibble <- rowData %>% 
         filter(!equal) %>% # filter not compatible ones, i.e., overlapping with annotations?? if we are going to include subset tx, then can we still do the filtering?? maybe not equal but can be compatible 
         dplyr::select(chr = chr.rc, start, end,
                       strand = strand.rc, intronStarts, intronEnds, confidenceType,
-                      readCount, geneReadProp, txFDR,geneFDR, numExons) %>%
+                      readCount, geneReadProp, txScore, geneScore, numExons) %>%
         filter(readCount > 1, # only use readCount>1 and highconfidence reads
                confidenceType == "highConfidenceJunctionReads") %>% 
         mutate(NSampleReadCount = (readCount >= min.readCount), 
                # number of samples passed read count criteria
                NSampleReadProp = (geneReadProp >= min.readFractionByGene),
                # number of samples passed gene read prop criteria
-               NSampleGeneFDR = (geneFDR <= max.geneFDR),
-               NSampleTxFDR = ((txFDR <= max.txFDR.multiExon & numExons >= 2) |
-                (txFDR <= max.txFDR.singleExon & numExons == 1))) %>%
+               NSampleGeneScore = (geneScore >= min.geneScore),
+               NSampleTxScore = ((txScore >= min.txScore.multiExon & numExons >= 2) |
+                (txScore >= min.txScore.singleExon & numExons == 1))) %>%
         select(all_of(c(group_var, sum_var))) 
     return(featureTibble)
 }
@@ -206,8 +206,8 @@ extractFeaturesFromReadClassSE <- function(readClassSe, sample_id,
 #' @noRd
 combineUnsplicedTranscriptModels <- 
     function(readClassList,  bpParameters, stranded, min.readCount, 
-             min.readFractionByGene, max.geneFDR, max.txFDR.multiExon,
-             max.txFDR.singleExon, verbose){
+             min.readFractionByGene, min.geneScore, min.txScore.multiExon,
+             min.txScore.singleExon, verbose){
         start.ptm <- proc.time()
         newUnsplicedSeList <- 
             bplapply(seq_along(readClassList), function(sample_id)
@@ -230,8 +230,8 @@ combineUnsplicedTranscriptModels <-
         start.ptm <- proc.time()
         combinedUnsplicedTibble <- 
             makeUnsplicedTibble(combinedNewUnsplicedSe,newUnsplicedSeList, 
-                                colDataNames, min.readCount, min.readFractionByGene, max.geneFDR,
-                                max.txFDR.multiExon, max.txFDR.singleExon, bpParameters)
+                                colDataNames, min.readCount, min.readFractionByGene, min.geneScore,
+                                min.txScore.multiExon, min.txScore.singleExon, bpParameters)
         end.ptm <- proc.time()
         if (verbose) message("combine new unspliced tibble object across all
         samples in ", round((end.ptm - start.ptm)[3] / 60, 1)," mins.")
@@ -282,7 +282,7 @@ reduceUnsplicedRanges <- function(rangesList, stranded){
 #'              ungroup
 makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
                                 colDataNames,min.readCount, min.readFractionByGene,
-                                max.geneFDR, max.txFDR.multiExon, max.txFDR.singleExon, 
+                                min.geneScore, min.txScore.multiExon, min.txScore.singleExon, 
                                 bpParameters){
     newUnsplicedTibble <- as_tibble(combinedNewUnsplicedSe) %>%
         rename(chr = seqnames) %>%
@@ -307,14 +307,14 @@ makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
         group_by(chr,strand, start, end, sample_name) %>%
         summarise(readCount = sum(readCount),
                   geneReadProp = sum(geneReadProp),
-                  geneFDR = weighted.mean(geneFDR, readCount_tmp),
-                  txFDR = weighted.mean(txFDR, readCount_tmp)) %>%
+                  geneScore = weighted.mean(geneScore, readCount_tmp),
+                  txScore = weighted.mean(txScore, readCount_tmp)) %>%
         group_by(chr, strand, start, end) %>% 
         summarise(readCount = sum(readCount),
-                  NSampleReadCount = sum(readCount >= min.readCount), 
-                  NSampleReadProp = sum(geneReadProp >= 
+                    NSampleReadCount = sum(readCount >= min.readCount), 
+                    NSampleReadProp = sum(geneReadProp >= 
                                             min.readFractionByGene),
-                  NSampleGeneFDR = sum(geneFDR <= max.geneFDR),
-                    NSampleTxFDR = sum(txFDR <= max.txFDR.singleExon))
+                    NSampleGeneScore = sum(geneScore >= min.geneScore),
+                    NSampleTxScore = sum(txScore >= min.txScore.singleExon))
     return(newUnsplicedTibble)
 }

--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -353,11 +353,12 @@ calculateDistToAnnotation <- function(exByTx, exByTxRef, maxDist = 35,
                                             primarySecondaryDist, DistCalculated = FALSE)
   # (2) calculate splice overlap for any not in the list (new exon >= 35bp)
   setTMP <- unique(txToAnTableFiltered$queryHits)
-  if(length(exByTx[-setTMP])>0){
-    spliceOverlaps_rest <- findSpliceOverlapsByDist(exByTx[-setTMP],
+
+  spliceOverlaps_rest <- findSpliceOverlapsByDist(exByTx[-setTMP],
                                                     exByTxRef, maxDist = 0, type = "any", firstLastSeparate = TRUE,
                                                     dropRangesByMinLength = FALSE, cutStartEnd = TRUE,
                                                     ignore.strand = ignore.strand)
+  if(length(spliceOverlaps_rest) > 0){
     txToAnTableRest <-
       genFilteredAnTable(spliceOverlaps_rest, primarySecondaryDist,
                         exByTx = exByTx, setTMP = setTMP, DistCalculated = FALSE)

--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -51,8 +51,8 @@ filterTranscriptsByRead <- function(combinedTranscripts, min.sampleNumber){
   if (nrow(combinedTranscripts) > 0) 
     filterSet <- combinedTranscripts$NSampleReadCount >= min.sampleNumber & (
       combinedTranscripts$NSampleReadProp >= min.sampleNumber) & (
-        combinedTranscripts$NSampleGeneFDR >= min.sampleNumber) & (
-          combinedTranscripts$NSampleTxFDR >= min.sampleNumber)
+        combinedTranscripts$NSampleGeneScore >= min.sampleNumber) & (
+          combinedTranscripts$NSampleTxScore >= min.sampleNumber)
   # filter based on read count and transcript usage
   return(filterSet)
 }

--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -353,31 +353,33 @@ calculateDistToAnnotation <- function(exByTx, exByTxRef, maxDist = 35,
                                             primarySecondaryDist, DistCalculated = FALSE)
   # (2) calculate splice overlap for any not in the list (new exon >= 35bp)
   setTMP <- unique(txToAnTableFiltered$queryHits)
-  spliceOverlaps_rest <- findSpliceOverlapsByDist(exByTx[-setTMP],
-                                                  exByTxRef, maxDist = 0, type = "any", firstLastSeparate = TRUE,
-                                                  dropRangesByMinLength = FALSE, cutStartEnd = TRUE,
-                                                  ignore.strand = ignore.strand)
-  txToAnTableRest <-
-    genFilteredAnTable(spliceOverlaps_rest, primarySecondaryDist,
-                       exByTx = exByTx, setTMP = setTMP, DistCalculated = FALSE)
-  # (3) find overlaps for remaining reads 
-  setTMPRest <- unique(c(txToAnTableRest$queryHits, setTMP))
-  txToAnTableRestStartEnd <- NULL
-  if (length(exByTx[-setTMPRest])) {
-    spliceOverlaps_restStartEnd <-
-      findSpliceOverlapsByDist(exByTx[-setTMPRest], exByTxRef,
-                               maxDist = 0, type = "any", firstLastSeparate = TRUE,
-                               dropRangesByMinLength = FALSE,
-                               cutStartEnd = FALSE, ignore.strand = ignore.strand)
-    if (length(spliceOverlaps_restStartEnd)) {
-      txToAnTableRestStartEnd <-
-        genFilteredAnTable(spliceOverlaps_restStartEnd,
-                           primarySecondaryDist, exByTx = exByTx,
-                           setTMP = setTMPRest, DistCalculated = TRUE)
+  if(length(exByTx[-setTMP])>0){
+    spliceOverlaps_rest <- findSpliceOverlapsByDist(exByTx[-setTMP],
+                                                    exByTxRef, maxDist = 0, type = "any", firstLastSeparate = TRUE,
+                                                    dropRangesByMinLength = FALSE, cutStartEnd = TRUE,
+                                                    ignore.strand = ignore.strand)
+    txToAnTableRest <-
+      genFilteredAnTable(spliceOverlaps_rest, primarySecondaryDist,
+                        exByTx = exByTx, setTMP = setTMP, DistCalculated = FALSE)
+    # (3) find overlaps for remaining reads 
+    setTMPRest <- unique(c(txToAnTableRest$queryHits, setTMP))
+    txToAnTableRestStartEnd <- NULL
+    if (length(exByTx[-setTMPRest])) {
+      spliceOverlaps_restStartEnd <-
+        findSpliceOverlapsByDist(exByTx[-setTMPRest], exByTxRef,
+                                maxDist = 0, type = "any", firstLastSeparate = TRUE,
+                                dropRangesByMinLength = FALSE,
+                                cutStartEnd = FALSE, ignore.strand = ignore.strand)
+      if (length(spliceOverlaps_restStartEnd)) {
+        txToAnTableRestStartEnd <-
+          genFilteredAnTable(spliceOverlaps_restStartEnd,
+                            primarySecondaryDist, exByTx = exByTx,
+                            setTMP = setTMPRest, DistCalculated = TRUE)
+      }
     }
-  }
-  txToAnTableFiltered <- rbind( txToAnTableFiltered,
-                                txToAnTableRest, txToAnTableRestStartEnd ) %>% ungroup()
+    txToAnTableFiltered <- rbind( txToAnTableFiltered,
+                                  txToAnTableRest, txToAnTableRestStartEnd ) %>% ungroup()
+  } else txToAnTableFiltered %>% ungroup()
   txToAnTableFiltered$readClassId <-
     names(exByTx)[txToAnTableFiltered$queryHits]
   txToAnTableFiltered$annotationTxId <-

--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -3,11 +3,11 @@
 #' @noRd
 isore.extendAnnotations <- function(combinedTranscripts, annotationGrangesList,
                                     remove.subsetTx = TRUE,
-                                    min.sampleNumber = 1, max.txFDR = 0.1, min.exonDistance = 35, min.exonOverlap = 10,
+                                    min.sampleNumber = 1, max.txNDR = 0.1, min.exonDistance = 35, min.exonOverlap = 10,
                                     min.primarySecondaryDist = 5, min.primarySecondaryDistStartEnd = 5, 
                                     prefix = "", verbose = FALSE){
   filterSet <- filterTranscriptsByRead(combinedTranscripts, min.sampleNumber)
-  filterSet <- filterTranscriptsByFDR(combinedTranscripts, filterSet, max.txFDR)
+  filterSet <- filterTranscriptsByNDR(combinedTranscripts, filterSet, max.txNDR)
   if (any(filterSet, na.rm = TRUE)) {
     transcriptsFiltered <- combinedTranscripts[filterSet,]
     group_var <- c("intronStarts","intronEnds","chr","strand","start","end",
@@ -57,23 +57,23 @@ filterTranscriptsByRead <- function(combinedTranscripts, min.sampleNumber){
   return(filterSet)
 }
 
-#' filter transcripts by FDR
+#' filter transcripts by NDR
 #' @noRd
-filterTranscriptsByFDR <- function(combinedTranscripts, filterSet, max.txFDR){
+filterTranscriptsByNDR <- function(combinedTranscripts, filterSet, max.txNDR){
   if (any(filterSet, na.rm = TRUE)) {
     combinedTranscripts <- combinedTranscripts[filterSet,]
   } else return(filterset)
 
-  # calculate and filter by FDR
+  # calculate and filter by NDR
   combinedTranscripts$equal[is.na(combinedTranscripts$equal)] = FALSE
   if(sum(combinedTranscripts$equal, na.rm = TRUE)<50 | 
       sum(!combinedTranscripts$equal, na.rm = TRUE)<50){
-        txFDR = 1 - combinedTranscripts$maxTxScore
+        txNDR = 1 - combinedTranscripts$maxTxScore
         warning("Less than 50 TRUE or FALSE read classes for precision stabilization. 
         Filtering by prediction score instead")
-  } else txFDR = calculateFDR(combinedTranscripts$maxTxScore, combinedTranscripts$equal)
+  } else txNDR = calculateNDR(combinedTranscripts$maxTxScore, combinedTranscripts$equal)
   index = which(filterSet)
-  filterSet[index] = filterSet[index] & (txFDR <= max.txFDR)
+  filterSet[index] = filterSet[index] & (txNDR <= max.txNDR)
   # remove equals to prevent duplicates when merging with anno
   filterSet[index] = filterSet[index] & (!combinedTranscripts$equal)
   return(filterSet)

--- a/R/bambu-extendAnnotations.R
+++ b/R/bambu-extendAnnotations.R
@@ -23,7 +23,7 @@ bambu.extendAnnotations <- function(readClassList, annotations,
         annotationGrangesList = annotations,
         remove.subsetTx = isoreParameters[["remove.subsetTx"]],
         min.sampleNumber = isoreParameters[["min.sampleNumber"]],
-        max.txFDR = isoreParameters[["max.txFDR"]],
+        max.txNDR = isoreParameters[["max.txNDR"]],
         min.exonDistance = isoreParameters[["min.exonDistance"]],
         min.exonOverlap = isoreParameters[["min.exonOverlap"]],
         min.primarySecondaryDist = 

--- a/R/bambu-extendAnnotations.R
+++ b/R/bambu-extendAnnotations.R
@@ -9,9 +9,9 @@ bambu.extendAnnotations <- function(readClassList, annotations,
         stranded, ## stranded used for unspliced reduce  
         min.readCount = isoreParameters[["min.readCount"]], 
         min.readFractionByGene = isoreParameters[["min.readFractionByGene"]],
-        max.geneFDR = isoreParameters[["max.geneFDR"]],
-        max.txFDR.multiExon = isoreParameters[["max.txFDR.multiExon"]],
-        max.txFDR.singleExon = isoreParameters[["max.txFDR.singleExon"]],
+        min.geneScore = isoreParameters[["min.geneScore"]],
+        min.txScore.multiExon = isoreParameters[["min.txScore.multiExon"]],
+        min.txScore.singleExon = isoreParameters[["min.txScore.singleExon"]],
         bpParameters,
         verbose)
     end.ptm_all <- proc.time()

--- a/R/bambu-extendAnnotations.R
+++ b/R/bambu-extendAnnotations.R
@@ -23,6 +23,7 @@ bambu.extendAnnotations <- function(readClassList, annotations,
         annotationGrangesList = annotations,
         remove.subsetTx = isoreParameters[["remove.subsetTx"]],
         min.sampleNumber = isoreParameters[["min.sampleNumber"]],
+        max.txFDR = isoreParameters[["max.txFDR"]],
         min.exonDistance = isoreParameters[["min.exonDistance"]],
         min.exonOverlap = isoreParameters[["min.exonOverlap"]],
         min.primarySecondaryDist = 

--- a/R/bambu-processReads_scoreReadClasses.R
+++ b/R/bambu-processReads_scoreReadClasses.R
@@ -117,6 +117,7 @@ getGeneScore = function(rowData, defaultModels, fit = TRUE){
         geneModel = fitXGBoostModel(labels.train=geneFeatures$labels,
         data.train=as.matrix(features), show.cv=FALSE)
         geneScore = as.numeric(predict(geneModel, as.matrix(features)))
+        #redundant function call since NDR is now calculated in extendAnno
         geneNDR = calculateNDR(geneScore, geneFeatures$labels)
     } else {
         warning("Gene Model not trained. Using pre-trained models, the NDR might not be adjusted correctly")
@@ -198,6 +199,7 @@ getTranscriptScore = function(rowData, defaultModels, fit = TRUE){
         txScoreSE = predict(transcriptModelSE, as.matrix(features))
         txScore[which(rowData$numExons==1)] =
             txScoreSE[which(rowData$numExons==1)]
+        #redundant function calls since NDR is now calculated in extendAnno
         txNDR = calculateNDR(txScore, txFeatures$labels)
         txNDR.ME = calculateNDR(txScore[which(rowData$numExons>=2)], txFeatures$labels[which(rowData$numExons>=2)])
         txNDR.SE = calculateNDR(txScore[which(rowData$numExons==1)], txFeatures$labels[which(rowData$numExons==1)])

--- a/R/bambu-processReads_utilityJunctionErrorCorrection.R
+++ b/R/bambu-processReads_utilityJunctionErrorCorrection.R
@@ -201,7 +201,7 @@ predictSpliceJunctions <- function(annotatedJunctions, junctionModel=NULL,
 #' @importFrom xgboost xgboost
 #' @importFrom stats fisher.test
 #' @noRd
-fitXGBoostModel <- function(labels.train, data.train, 
+fitXGBoostModel <- function(labels.train, data.train, nround = 50, 
                             show.cv=TRUE, maxSize.cv=10000){
     if (show.cv) {
         mySample <- sample(seq_along(labels.train),
@@ -212,7 +212,7 @@ fitXGBoostModel <- function(labels.train, data.train,
         labels.train.cv.test <- labels.train[-mySample]
 
         cv.fit <- xgboost(data = data.train.cv, 
-            label = labels.train.cv, nthread=1, nround= 50, 
+            label = labels.train.cv, nthread=1, nround=nround, 
             objective = "binary:logistic", 
             eval_metric='error',
             verbose = 0)
@@ -230,7 +230,7 @@ fitXGBoostModel <- function(labels.train, data.train,
     }
 
     cv.fit <- xgboost(data = data.train, 
-            label = labels.train, nthread=1, nround= 50, 
+            label = labels.train, nthread=1, nround=nround, 
             objective = "binary:logistic", 
             eval_metric='error',
             verbose = 0)

--- a/R/bambu.R
+++ b/R/bambu.R
@@ -49,7 +49,7 @@
 #'     threshold for multi-exon transcripts during sample combining
 #'     \item min.txScore.singleExon specifying the minimum transcript level 
 #'     threshold for single-exon transcripts during sample combining
-#'     \item max.txFDR. specifying the maximum FDR rate to novel transcript 
+#'     \item max.txNDR. specifying the maximum NDR rate to novel transcript 
 #'     output from detected read classes
 #' }
 #' @param opt.em A list of controlling parameters for quantification

--- a/R/bambu.R
+++ b/R/bambu.R
@@ -44,8 +44,11 @@
 #'     of distance threshold, used for extending annotation
 #'     \item min.primarySecondaryDistStartEnd2 specifying the minimum number 
 #'     of distance threshold, used for estimating distance to annotation
-#'     \item max.geneFDR specifying the maximum FDR rate for gene level 
-#'     threshold
+#'     \item min.geneScore specifying the minimum score for gene detection
+#'     \item min.txScore.multiExon specifying the minimum transcript level 
+#'     threshold for multi-exon transcripts during sample combining
+#'     \item min.txScore.singleExon specifying the minimum transcript level 
+#'     threshold for single-exon transcripts during sample combining
 #'     \item max.txFDR.multiExon specifying the maximum FDR rate for transcript level 
 #'     threshold for multi-exon transcripts 
 #'     \item max.txFDR.singleExon specifying the maximum FDR rate for transcript level 

--- a/R/bambu.R
+++ b/R/bambu.R
@@ -49,10 +49,8 @@
 #'     threshold for multi-exon transcripts during sample combining
 #'     \item min.txScore.singleExon specifying the minimum transcript level 
 #'     threshold for single-exon transcripts during sample combining
-#'     \item max.txFDR.multiExon specifying the maximum FDR rate for transcript level 
-#'     threshold for multi-exon transcripts 
-#'     \item max.txFDR.singleExon specifying the maximum FDR rate for transcript level 
-#'     threshold for single-exon transcripts (defaults to max.txFDR.multiExon)
+#'     \item max.txFDR. specifying the maximum FDR rate to novel transcript 
+#'     output from detected read classes
 #' }
 #' @param opt.em A list of controlling parameters for quantification
 #' algorithm estimation process:

--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -31,7 +31,7 @@ setIsoreParameters <- function(isoreParameters){
         min.geneScore = 0,
         min.txScore.multiExon = 0,
         min.txScore.singleExon = 1,
-        max.txFDR = 0.1,
+        max.txNDR = 0.1,
         fitReadClassModel = TRUE,
         prefix = "") 
     isoreParameters <- 

--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -28,7 +28,7 @@ setIsoreParameters <- function(isoreParameters){
         min.primarySecondaryDistStartEnd1 = 5, # for creating new annotations
         min.primarySecondaryDistStartEnd2 = 5, # for read assignment
         min.exonOverlap = 10,
-        min.geneScore = 0,
+        min.geneScore = 0.2,
         min.txScore.multiExon = 0,
         min.txScore.singleExon = 1,
         max.txNDR = 0.1,

--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -31,8 +31,7 @@ setIsoreParameters <- function(isoreParameters){
         min.geneScore = 0.5,
         min.txScore.multiExon = 0.5,
         min.txScore.singleExon = NULL,
-        max.txFDR.multiExon = 0.1,
-        max.txFDR.singleExon = NULL,
+        max.txFDR = 0.1,
         fitReadClassModel = TRUE,
         prefix = "") 
     isoreParameters <- 

--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -28,15 +28,17 @@ setIsoreParameters <- function(isoreParameters){
         min.primarySecondaryDistStartEnd1 = 5, # for creating new annotations
         min.primarySecondaryDistStartEnd2 = 5, # for read assignment
         min.exonOverlap = 10,
-        max.geneFDR = 0.01,
+        min.geneScore = 0.5,
+        min.txScore.multiExon = 0.5,
+        min.txScore.singleExon = NULL,
         max.txFDR.multiExon = 0.1,
         max.txFDR.singleExon = NULL,
         fitReadClassModel = TRUE,
         prefix = "") 
     isoreParameters <- 
         updateParameters(isoreParameters, isoreParameters.default)
-    if(is.null(isoreParameters$max.txFDR.singleExon)){
-        isoreParameters$max.txFDR.singleExon = isoreParameters$max.txFDR.multiExon}
+    if(is.null(isoreParameters$min.txScore.singleExon)){
+        isoreParameters$min.txScore.singleExon = isoreParameters$min.txScore.multiExon}
     return(isoreParameters)
 }
 

--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -28,9 +28,9 @@ setIsoreParameters <- function(isoreParameters){
         min.primarySecondaryDistStartEnd1 = 5, # for creating new annotations
         min.primarySecondaryDistStartEnd2 = 5, # for read assignment
         min.exonOverlap = 10,
-        min.geneScore = 0.5,
-        min.txScore.multiExon = 0.5,
-        min.txScore.singleExon = NULL,
+        min.geneScore = 0,
+        min.txScore.multiExon = 0,
+        min.txScore.singleExon = 1,
         max.txFDR = 0.1,
         fitReadClassModel = TRUE,
         prefix = "") 


### PR DESCRIPTION
Improve the performance of Bambu when large amounts of annotations are missing.

Gene Model now only has 5 rounds of xgboost to stop overfitting on the smaller amount of data
TRUE genes are now if any of their gene members are compatible with at least one annotation
Gene read prop is calculated under the bambu gene definition and does not use annotations
Annotations are now filtered by a geneScore of 0.2
assignNewGeneIds() has been removed and all calls of it have been replaced by the faster assignGeneIds()