### PR TITLE
fix bugs for small samples

### DIFF
--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -327,15 +327,19 @@ calculateDistToAnnotation <- function(exByTx, exByTxRef, maxDist = 35,
                                              maxDist = maxDist, firstLastSeparate = TRUE,
                                              dropRangesByMinLength = TRUE, cutStartEnd = TRUE,
                                              ignore.strand = ignore.strand)
-  txToAnTableFiltered <- genFilteredAnTable(spliceOverlaps,
-                                            primarySecondaryDist, DistCalculated = FALSE)
+  if(length(spliceOverlaps)==0) txToAnTableFiltered <- NULL
+  else txToAnTableFiltered <- genFilteredAnTable(spliceOverlaps,
+                                                 primarySecondaryDist, DistCalculated = FALSE)
   # (2) calculate splice overlap for any not in the list (new exon >= 35bp)
   setTMP <- unique(txToAnTableFiltered$queryHits)
-  spliceOverlaps_rest <- findSpliceOverlapsByDist(exByTx[-setTMP],
+  if(length(setTMP)==0) exByTx_rest <- exByTx
+  else exByTx_rest <- exByTx[-setTMP]
+  spliceOverlaps_rest <- findSpliceOverlapsByDist(exByTx_rest,
                                                   exByTxRef, maxDist = 0, type = "any", firstLastSeparate = TRUE,
                                                   dropRangesByMinLength = FALSE, cutStartEnd = TRUE,
                                                   ignore.strand = ignore.strand)
-  txToAnTableRest <-
+  if(length(spliceOverlaps_rest)==0) txToAnTableRest <- NULL
+  else txToAnTableRest <-
     genFilteredAnTable(spliceOverlaps_rest, primarySecondaryDist,
                        exByTx = exByTx, setTMP = setTMP, DistCalculated = FALSE)
   # (3) find overlaps for remaining reads 
@@ -389,8 +393,9 @@ genFilteredAnTable <- function(spliceOverlaps, primarySecondaryDist = 5,
   }
   ## change query hits for step 2 and 3
   if (!is.null(exByTx)) {
-    txToAnTable$queryHits <-
-      (seq_along(exByTx))[-setTMP][txToAnTable$queryHits]
+    if(is.null(setTMP)) txToAnTable$queryHits <- txToAnTable$queryHits <-
+        (seq_along(exByTx))[txToAnTable$queryHits]
+    else (seq_along(exByTx))[-setTMP][txToAnTable$queryHits]
   }
   ## todo: check filters, what happens to reads with only start and end match?
   if (isFALSE(DistCalculated)) {

--- a/R/bambu-processReads_utilityConstructReadClasses.R
+++ b/R/bambu-processReads_utilityConstructReadClasses.R
@@ -1,4 +1,3 @@
-
 #' Isoform reconstruction using genomic alignments
 #' @param readGrgList readGrgList
 #' @param unlisted_junctions unlisted_junctions
@@ -10,11 +9,11 @@
 #' @inheritParams bambu
 #' @noRd
 isore.constructReadClasses <- function(readGrgList, unlisted_junctions,
-    uniqueJunctions, runName = "sample1",
-    annotations, stranded = FALSE, verbose = FALSE) {
+                                       uniqueJunctions, runName = "sample1",
+                                       annotations, stranded = FALSE, verbose = FALSE) {
     #split reads into single exon and multi exon reads
     reads.singleExon <- unlist(readGrgList[elementNROWS(readGrgList) == 1],
-        use.names = FALSE)
+                               use.names = FALSE)
     mcols(reads.singleExon)$id <- mcols(readGrgList[
         elementNROWS(readGrgList) == 1])$id
     #only keep multi exons reads in readGrgList    
@@ -30,17 +29,18 @@ isore.constructReadClasses <- function(readGrgList, unlisted_junctions,
         stranded = stranded)
     end.ptm <- proc.time()
     if (verbose) 
-    message("Finished create transcript models (read classes) for reads with
+        message("Finished create transcript models (read classes) for reads with
     spliced junctions in ", round((end.ptm - start.ptm)[3] / 60, 1)," mins.")
-    exonsByRC.unspliced <- constructUnsplicedReadClasses(reads.singleExon, 
-        annotations, exonsByRC.spliced, stranded, verbose)
+    if(length(reads.singleExon)==0) exonsByRC.unspliced <- NULL
+    else exonsByRC.unspliced <- constructUnsplicedReadClasses(reads.singleExon, 
+                                                              annotations, exonsByRC.spliced, stranded, verbose)
     exonsByRC <- c(exonsByRC.spliced, exonsByRC.unspliced)
     colDataDf <- DataFrame(name = runName, row.names = runName)
     #TODO later remove assays = SimpleList(counts = counts)
     counts <- matrix(mcols(exonsByRC)$readCount,
-        dimnames = list(names(exonsByRC), runName))
+                     dimnames = list(names(exonsByRC), runName))
     se <- SummarizedExperiment(assays = SimpleList(counts = counts),
-        rowRanges = exonsByRC, colData = colDataDf)
+                               rowRanges = exonsByRC, colData = colDataDf)
     return(se)
 }
 
@@ -51,16 +51,16 @@ isore.constructReadClasses <- function(readGrgList, unlisted_junctions,
 #' @importFrom GenomicRanges match
 #' @noRd
 constructSplicedReadClasses <- function(uniqueJunctions, unlisted_junctions, 
-    readGrgList, stranded = FALSE) {
+                                        readGrgList, stranded = FALSE) {
     options(scipen = 999)
     allToUniqueJunctionMatch <- GenomicRanges::match(unlisted_junctions,
-        uniqueJunctions, ignore.strand = TRUE)
+                                                     uniqueJunctions, ignore.strand = TRUE)
     correctedJunctionMatches <- 
         base::match(uniqueJunctions$mergedHighConfJunctionIdAll_noNA[
             allToUniqueJunctionMatch], names(uniqueJunctions))
-
+    
     unlisted_junctions <- correctIntronRanges(unlisted_junctions, 
-        uniqueJunctions, correctedJunctionMatches)
+                                              uniqueJunctions, correctedJunctionMatches)
     if(any(mcols(unlisted_junctions)$remove)){  # remove microexons
         toRemove = which(mcols(unlisted_junctions)$remove)
         unlisted_junctions = unlisted_junctions[-toRemove]
@@ -73,24 +73,24 @@ constructSplicedReadClasses <- function(uniqueJunctions, unlisted_junctions,
     } else {
         readStrand <- as.factor(getStrandFromGrList(readGrgList))
     }
-
+    
     # confidence type (note: can be changed to integer encoding)
     readConfidence <- factor(rep("highConfidenceJunctionReads",
-        length(readStrand)), levels = c('highConfidenceJunctionReads',
-        'lowConfidenceJunctionReads'))
+                                 length(readStrand)), levels = c('highConfidenceJunctionReads',
+                                                                 'lowConfidenceJunctionReads'))
     lowConfidenceReads <- which(sum(is.na(splitAsList(
         uniqueJunctions$mergedHighConfJunctionId[allToUniqueJunctionMatch],
         mcols(unlisted_junctions)$id))) > 0)
     readConfidence[lowConfidenceReads] <- "lowConfidenceJunctionReads"
     
     readTable <- createReadTable(unlisted_junctions, readGrgList,
-        readStrand, readConfidence)
+                                 readStrand, readConfidence)
     exonsByReadClass <- createExonsByReadClass(readTable)
     
     readTable <- readTable %>% dplyr::select(chr.rc = chr, strand.rc = strand,
-        startSD = startSD, endSD = endSD, 
-        readCount.posStrand = readCount.posStrand, intronStarts, intronEnds, 
-        confidenceType, readCount)
+                                             startSD = startSD, endSD = endSD, 
+                                             readCount.posStrand = readCount.posStrand, intronStarts, intronEnds, 
+                                             confidenceType, readCount)
     mcols(exonsByReadClass) <- readTable
     options(scipen = 0)
     return(exonsByReadClass)
@@ -103,27 +103,27 @@ constructSplicedReadClasses <- function(uniqueJunctions, unlisted_junctions,
 correctIntronRanges <- function(unlisted_junctions, uniqueJunctions,
                                 correctedJunctionMatches){
     intronStartTMP <-
-            start(uniqueJunctions)[correctedJunctionMatches]
-
+        start(uniqueJunctions)[correctedJunctionMatches]
+    
     intronEndTMP <-
-    end(uniqueJunctions)[correctedJunctionMatches]
-
+        end(uniqueJunctions)[correctedJunctionMatches]
+    
     exon_0size <- 
-            which(intronStartTMP[-1] <= intronEndTMP[-length(intronEndTMP)] &
-            mcols(unlisted_junctions)$id[-1] == 
-            mcols(unlisted_junctions)$id[-length(unlisted_junctions)])
-
+        which(intronStartTMP[-1] <= intronEndTMP[-length(intronEndTMP)] &
+                  mcols(unlisted_junctions)$id[-1] == 
+                  mcols(unlisted_junctions)$id[-length(unlisted_junctions)])
+    
     start(unlisted_junctions) <- intronStartTMP
     end(unlisted_junctions) <- intronEndTMP
     strand(unlisted_junctions) <-
-    uniqueJunctions$strand.mergedHighConfJunction[correctedJunctionMatches]
-
+        uniqueJunctions$strand.mergedHighConfJunction[correctedJunctionMatches]
+    
     #remove micro exons and adjust respective junctions
     start(unlisted_junctions)[exon_0size+1]=
         start(unlisted_junctions)[exon_0size]
     mcols(unlisted_junctions)$remove <- rep(FALSE, length(unlisted_junctions))
     mcols(unlisted_junctions)$remove[exon_0size] <- TRUE
-
+    
     return(unlisted_junctions)
 }
 
@@ -153,33 +153,33 @@ correctReadStrandById <- function(strand, id, stranded = FALSE){
 #'     row_number .groups
 #' @noRd
 createReadTable <- function(unlisted_junctions, readGrgList,
-    readStrand, readConfidence) {
+                            readStrand, readConfidence) {
     readRanges <- unlist(range(ranges(readGrgList)), use.names = FALSE)
     intronStartCoordinatesInt <- 
         as.integer(min(splitAsList(start(unlisted_junctions),
-        mcols(unlisted_junctions)$id)) - 2)
+                                   mcols(unlisted_junctions)$id)) - 2)
     intronEndCoordinatesInt <- 
         as.integer(max(splitAsList(end(unlisted_junctions),
-        mcols(unlisted_junctions)$id)) + 2)
+                                   mcols(unlisted_junctions)$id)) + 2)
     readTable <- tibble(chr = as.factor(getChrFromGrList(readGrgList)), 
-        intronStarts = 
-        unname(unstrsplit(splitAsList(as.character(start(unlisted_junctions)),
-            mcols(unlisted_junctions)$id), sep = ",")),
-        intronEnds = 
-            unname(unstrsplit(splitAsList(as.character(end(unlisted_junctions)),
-                mcols(unlisted_junctions)$id), sep = ",")),
-        start = pmin(start(readRanges), intronStartCoordinatesInt),
-        end = pmax(end(readRanges), intronEndCoordinatesInt),
-        strand = readStrand, confidenceType = readConfidence,
-        alignmentStrand = as.character(getStrandFromGrList(readGrgList))=='+')
+                        intronStarts = 
+                            unname(unstrsplit(splitAsList(as.character(start(unlisted_junctions)),
+                                                          mcols(unlisted_junctions)$id), sep = ",")),
+                        intronEnds = 
+                            unname(unstrsplit(splitAsList(as.character(end(unlisted_junctions)),
+                                                          mcols(unlisted_junctions)$id), sep = ",")),
+                        start = pmin(start(readRanges), intronStartCoordinatesInt),
+                        end = pmax(end(readRanges), intronEndCoordinatesInt),
+                        strand = readStrand, confidenceType = readConfidence,
+                        alignmentStrand = as.character(getStrandFromGrList(readGrgList))=='+')
     ## currently 80%/20% quantile of reads is used to identify start/end sites
     readTable <- readTable %>% 
         group_by(chr, strand, intronEnds, intronStarts, confidenceType) %>% 
         summarise(readCount = n(), startSD = sd(start), endSD = sd(end),
-        start = nth(x = start, n = ceiling(readCount / 5), order_by = start),
-        end = nth(x = end, n = ceiling(readCount / 1.25), order_by = end), 
-        readCount.posStrand = sum(alignmentStrand, na.rm = TRUE),
-        .groups = 'drop') %>% arrange(chr, start, end) %>%
+                  start = nth(x = start, n = ceiling(readCount / 5), order_by = start),
+                  end = nth(x = end, n = ceiling(readCount / 1.25), order_by = end), 
+                  readCount.posStrand = sum(alignmentStrand, na.rm = TRUE),
+                  .groups = 'drop') %>% arrange(chr, start, end) %>%
         mutate(readClassId = paste("rc", row_number(), sep = "."))
     return(readTable)
 }
@@ -207,7 +207,7 @@ createExonsByReadClass <- function(readTable){
     # add exon rank and exon_endRank
     unlistData <- unlist(exonsByReadClass, use.names = FALSE)
     partitioning <- PartitioningByEnd(cumsum(elementNROWS(exonsByReadClass)),
-        names = NULL)
+                                      names = NULL)
     exon_rank <- lapply(width(partitioning), seq, from = 1)
     exon_rank[which(readTable$strand == "-")] <-
         lapply(exon_rank[which(readTable$strand == "-")], rev)
@@ -223,12 +223,12 @@ createExonsByReadClass <- function(readTable){
 #' @importFrom GenomicRanges granges unlist reduce 
 #' @noRd
 constructUnsplicedReadClasses <- function(reads.singleExon, annotations, 
-        readClassListSpliced, stranded, verbose = FALSE){
+                                          readClassListSpliced, stranded, verbose = FALSE){
     start.ptm <- proc.time()
     referenceExons <- unique(c(granges(unlist(
         readClassListSpliced[mcols(readClassListSpliced)$confidenceType ==
-            "highConfidenceJunctionReads" &
-            mcols(readClassListSpliced)$strand.rc != "*"], 
+                                 "highConfidenceJunctionReads" &
+                                 mcols(readClassListSpliced)$strand.rc != "*"], 
         use.names = FALSE)),
         granges(unlist(annotations, use.names = FALSE))))
     #(1) reads fall into annotations or spliced read classes are summarised
@@ -237,7 +237,7 @@ constructUnsplicedReadClasses <- function(reads.singleExon, annotations,
         granges = reads.singleExon, grangesReference = referenceExons,
         confidenceType = "unsplicedWithin", stranded = stranded)
     reads.singleExon <- reads.singleExon[!mcols(reads.singleExon)$id %in%
-        rcUnsplicedAnnotation$readIds]
+                                             rcUnsplicedAnnotation$readIds]
     referenceExons <- reduce(reads.singleExon, ignore.strand = !stranded)
     #(2) reads do not fall within a annotated exon/high confidence read class 
     # exon are summarised based on the union of overlapping unspliced reads
@@ -248,7 +248,7 @@ constructUnsplicedReadClasses <- function(reads.singleExon, annotations,
     if (verbose) message("Finished create single exon transcript models
         (read classes) in ", round((end.ptm - start.ptm)[3] / 60, 1), " mins.")
     exonsByReadClass <- c(rcUnsplicedAnnotation$exonsByReadClass, 
-        rcUnsplicedReduced$exonsByReadClass)
+                          rcUnsplicedReduced$exonsByReadClass)
     return(exonsByReadClass)
 }
 
@@ -261,13 +261,13 @@ constructUnsplicedReadClasses <- function(reads.singleExon, annotations,
 #'     ungroup distinct 
 #' @noRd
 getUnsplicedReadClassByReference <- function(granges, grangesReference,
-    confidenceType = "unspliced", stranded = TRUE) {
+                                             confidenceType = "unspliced", stranded = TRUE) {
     if (is.null(mcols(granges)$id))
         stop("ID column is missing from mcols(granges)")
     hitsWithin <- findOverlaps(granges, grangesReference,
-        ignore.strand = !stranded, 
-        type = "within", 
-        select = "all")
+                               ignore.strand = !stranded, 
+                               type = "within", 
+                               select = "all")
     # find reads that overlap with reference ranges
     hitsDF <- initiateHitsDF(hitsWithin, grangesReference, stranded)
     ## create single exon read class by using the minimum end
@@ -278,21 +278,21 @@ getUnsplicedReadClassByReference <- function(granges, grangesReference,
         summarise(start = max(start), end = min(end), .groups = "drop") %>%
         group_by(chr, start, end, strand) %>%
         mutate(readClassId = paste0("rc", confidenceType, ".", 
-            cur_group_id())) %>% ungroup() %>%
+                                    cur_group_id())) %>% ungroup() %>%
         mutate(alignmentStrand = as.character(strand(granges))[queryHits]=="+",
-            readStart = start(granges)[queryHits],
-            readEnd = end(granges)[queryHits])
+               readStart = start(granges)[queryHits],
+               readEnd = end(granges)[queryHits])
     readIds <- mcols(granges[hitsDF$queryHits])$id
     #previously it took the first rows strand for a read class id
     # which could be wrong, coded in an alternative but its likely very slow...
     hitsDF <- hitsDF %>% dplyr::select(chr, start, end, readStart, readEnd, 
-                                strand, readClassId, alignmentStrand) %>%
+                                       strand, readClassId, alignmentStrand) %>%
         group_by(readClassId) %>% summarise(start = start[1], end = end[1], 
-        strand = strand[1], chr = chr[1], readCount = n(),
-        startSD = sd(readStart), endSD = sd(readEnd), 
-        readCount.posStrand = sum(alignmentStrand)) %>% 
+                                            strand = strand[1], chr = chr[1], readCount = n(),
+                                            startSD = sd(readStart), endSD = sd(readEnd), 
+                                            readCount.posStrand = sum(alignmentStrand)) %>% 
         mutate(confidenceType = confidenceType, intronStarts = NA,
-            intronEnds = NA)
+               intronEnds = NA)
     exByReadClassUnspliced <- GenomicRanges::GRanges(
         seqnames = hitsDF$chr,
         ranges = IRanges(start = hitsDF$start, end = hitsDF$end),
@@ -303,8 +303,8 @@ getUnsplicedReadClassByReference <- function(granges, grangesReference,
     exByReadClassUnspliced <- relist(exByReadClassUnspliced, partitioning)
     names(exByReadClassUnspliced) <- hitsDF$readClassId
     hitsDF <- dplyr::select(hitsDF, chr.rc = chr, strand.rc = strand,
-        intronStarts, intronEnds,
-        confidenceType, readCount, startSD, endSD, readCount.posStrand)
+                            intronStarts, intronEnds,
+                            confidenceType, readCount, startSD, endSD, readCount.posStrand)
     mcols(exByReadClassUnspliced) <- hitsDF
     return(list(exonsByReadClass = exByReadClassUnspliced, readIds = readIds))
 }
@@ -359,12 +359,12 @@ assignGeneIdsByReference <- function(grl, annotations) {
     ## next for non unique hits select one gene (maximum overlap)
     multiHits <- which(queryHits(ov) %in% which(countQueryHits(ov)>1))
     expandedRanges <- expandRangesList(ranges(grl[queryHits(ov)[multiHits]]),
-                        ranges(geneRanges[subjectHits(ov)[multiHits]]))
+                                       ranges(geneRanges[subjectHits(ov)[multiHits]]))
     rangeIntersect <- pintersect(expandedRanges, 
-        mcols(expandedRanges)$matchRng, resolve.empty = 'start.x')
+                                 mcols(expandedRanges)$matchRng, resolve.empty = 'start.x')
     intersectById <- tapply(width(rangeIntersect), 
-        mcols(expandedRanges)$IdMap, sum)
-
+                            mcols(expandedRanges)$IdMap, sum)
+    
     filteredMultiHits <- as_tibble(ov[multiHits]) %>% 
         mutate(intersectWidth = intersectById) %>% 
         group_by(queryHits) %>% arrange(desc(intersectWidth)) %>% 
@@ -373,7 +373,7 @@ assignGeneIdsByReference <- function(grl, annotations) {
         names(geneRanges)[filteredMultiHits$subjectHits]
     
     return(geneIds)
-    }
+}
 
 #' Create new gene ids for groups of overlapping read classes which 
 #' don't overlap with known annotations. 
@@ -382,7 +382,7 @@ assignGeneIdsNoReference <- function(grl) {
     newTxIds <- seq_len(length(grl))
     newGeneByNewTxId <- rep(NA, length(newTxIds))
     if(length(grl)==0){
-    return(newGeneByNewTxId)
+        return(newGeneByNewTxId)
     }
     newTxIdsByExon <- rep(newTxIds, times=elementNROWS(grl))
     grSetReduced <- reduce(unlist(grl), with.revmap=TRUE)
@@ -392,11 +392,11 @@ assignGeneIdsNoReference <- function(grl) {
     newTxIdsByMergedExon <- newTxIdsByExon[unlist(revmap)]
     # (1) create initial gene, exon, transcript map
     exonTxMap <- tibble(newExonId=newExonIdByMergedExon, 
-        newTxId=newTxIdsByMergedExon) %>% distinct()
+                        newTxId=newTxIdsByMergedExon) %>% distinct()
     geneExonMap <-tibble(newGeneId=newExonIdByMergedExon, 
-        newExonId=newExonIdByMergedExon) %>% distinct()
+                         newExonId=newExonIdByMergedExon) %>% distinct()
     geneTxMap <- tibble(newGeneId=newExonIdByMergedExon, 
-        newTxId=newTxIdsByMergedExon) %>% distinct()
+                        newTxId=newTxIdsByMergedExon) %>% distinct()
     # (2) select genes with only unique transcripts (complete assignment)
     exonGeneMap_filter1 <-  geneTxMap %>% group_by(newTxId) %>% 
         mutate(nTx=n()) %>% group_by(newGeneId) %>% filter(sum(nTx)==n()) 
@@ -405,7 +405,7 @@ assignGeneIdsNoReference <- function(grl) {
     
     if(any(is.na(newGeneByNewTxId))) {
         refGeneTxMap = assignGeneIdsNonAssigned(geneTxMap, exonTxMap, 
-            geneExonMap, exonGeneMap_filter1, newExonId)
+                                                geneExonMap, exonGeneMap_filter1, newExonId)
         newGeneIds = paste0("gene.", refGeneTxMap$newGeneId)
         newGeneByNewTxId[refGeneTxMap$newTxId]<-newGeneIds
     }
@@ -414,53 +414,53 @@ assignGeneIdsNoReference <- function(grl) {
 
 #' Interal function which groups read classes that overlap
 assignGeneIdsNonAssigned = function(geneTxMap, exonTxMap, geneExonMap, 
-        exonGeneMap_filter1, newExonId){
+                                    exonGeneMap_filter1, newExonId){
     # (3.1) second iteration: non assigned genes
     geneTxMap <- geneTxMap %>% 
-    filter(!(newGeneId %in% exonGeneMap_filter1$newGeneId))
+        filter(!(newGeneId %in% exonGeneMap_filter1$newGeneId))
     exonTxMap <- exonTxMap %>% 
-    filter(!(newTxId %in% exonGeneMap_filter1$newTxId))
+        filter(!(newTxId %in% exonGeneMap_filter1$newTxId))
     geneExonMap <- geneExonMap %>% 
-    filter(!(newGeneId %in% exonGeneMap_filter1$newGeneId))
+        filter(!(newGeneId %in% exonGeneMap_filter1$newGeneId))
     
     ## (1) select gene Ids (first exons, can't be merged)
     refGeneExonList = getRefGeneExonList(exonTxMap, geneExonMap)
     #extend to the right
     refGeneTxMap <- left_join(refGeneExonList,  exonTxMap, 
-    by=c('newExonId.merge'='newExonId')) %>% 
-    dplyr::select(newGeneId, newTxId) %>% distinct()
+                              by=c('newExonId.merge'='newExonId')) %>% 
+        dplyr::select(newGeneId, newTxId) %>% distinct()
     refGeneTxMap <- rbind(geneTxMap %>% filter(newGeneId %in% 
-    refGeneTxMap$newGeneId), refGeneTxMap) %>% distinct()
+                                                   refGeneTxMap$newGeneId), refGeneTxMap) %>% distinct()
     refGenExonMap <- left_join(refGeneTxMap, exonTxMap, by = "newTxId") %>% 
-    dplyr::select(newGeneId, newExonId) %>% distinct()
+        dplyr::select(newGeneId, newExonId) %>% distinct()
     length_tmp = 0
     while(length_tmp<nrow(refGenExonMap)) {
         length_tmp=nrow(refGenExonMap)
         refGeneTxMap <- left_join(refGenExonMap,  exonTxMap,
-            by = "newExonId") %>% 
+                                  by = "newExonId") %>% 
             dplyr::select(newGeneId, newTxId) %>% distinct()
         refGenExonMap <- left_join(refGeneTxMap, exonTxMap,
-            by = "newTxId") %>% 
+                                   by = "newTxId") %>% 
             dplyr::select(newGeneId, newExonId) %>% distinct()
     }
     # combined gene ids
     geneGeneMap <- left_join(refGeneTxMap, dplyr::rename(refGeneTxMap, 
-    newGeneId.merge=newGeneId), by = "newTxId") %>% 
-    filter(newGeneId<newGeneId.merge) %>% 
-    filter(!(newGeneId %in% newGeneId.merge)) %>% 
-    dplyr::select(newGeneId, newGeneId.merge) %>% distinct()
+                                                         newGeneId.merge=newGeneId), by = "newTxId") %>% 
+        filter(newGeneId<newGeneId.merge) %>% 
+        filter(!(newGeneId %in% newGeneId.merge)) %>% 
+        dplyr::select(newGeneId, newGeneId.merge) %>% distinct()
     refGeneTxMap <- rbind(refGeneTxMap %>% filter(!(newGeneId %in% 
-        geneGeneMap$newGeneId.merge)), left_join(geneGeneMap, refGeneTxMap, 
-        by=c('newGeneId.merge'='newGeneId')) %>% 
-        dplyr::select(newGeneId, newTxId)) %>% distinct()
+                                                        geneGeneMap$newGeneId.merge)), left_join(geneGeneMap, refGeneTxMap, 
+                                                                                                 by=c('newGeneId.merge'='newGeneId')) %>% 
+                              dplyr::select(newGeneId, newTxId)) %>% distinct()
     return(refGeneTxMap)
 }
 
 #' Small function to meet bioconductor formatting requirements
 getRefGeneExonList = function(exonTxMap, geneExonMap){
     refGeneExonList <- left_join(exonTxMap, 
-        dplyr::rename(exonTxMap, newExonId.merge=newExonId), 
-        by = "newTxId") %>% 
+                                 dplyr::rename(exonTxMap, newExonId.merge=newExonId), 
+                                 by = "newTxId") %>% 
         filter(newExonId<newExonId.merge) %>% 
         filter(!(newExonId %in% newExonId.merge)) %>% 
         dplyr::select(newExonId, newExonId.merge) %>% 
@@ -468,5 +468,3 @@ getRefGeneExonList = function(exonTxMap, geneExonMap){
         dplyr::select(newGeneId, newExonId.merge) %>% distinct()
     return(refGeneExonList)
 }
-
-


### PR DESCRIPTION
-  set single exon read class object to NULL when there is no single exon read class 
-  set relevant object variables to NULL when no splice overlaps found between read class and annotations
-  add if statement to avoid error calling when index variables are NULL