### PR TITLE
Fix crash when no novel anntoations found

### DIFF
--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -94,15 +94,17 @@ filterTranscriptsByAnnotation <- function(rowDataCombined, annotationGrangesList
   geneListWithNewTx <- which(mcols(extendedAnnotationRanges)$GENEID %in%
                                mcols(extendedAnnotationRanges)$GENEID[
                                  which(mcols(extendedAnnotationRanges)$newTxClass != "annotation")])
-  minEqClasses <-
-    getMinimumEqClassByTx(extendedAnnotationRanges[geneListWithNewTx])
-  end.ptm <- proc.time()
-  if (verbose) message("calculated minimum equivalent classes for
-        extended annotations in ", round((end.ptm - start.ptm)[3] / 60, 1),
-                       " mins.")
-  mcols(extendedAnnotationRanges)$eqClass[geneListWithNewTx] <-
-    minEqClasses$eqClass[match(names(extendedAnnotationRanges[
-      geneListWithNewTx]), minEqClasses$queryTxId)]
+  if(length(geneListWithNewTx)>0){
+    minEqClasses <-
+        getMinimumEqClassByTx(extendedAnnotationRanges[geneListWithNewTx])
+    end.ptm <- proc.time()
+    if (verbose) message("calculated minimum equivalent classes for
+            extended annotations in ", round((end.ptm - start.ptm)[3] / 60, 1),
+                        " mins.")
+    mcols(extendedAnnotationRanges)$eqClass[geneListWithNewTx] <-
+        minEqClasses$eqClass[match(names(extendedAnnotationRanges[
+        geneListWithNewTx]), minEqClasses$queryTxId)]
+  }
   mcols(extendedAnnotationRanges) <- mcols(extendedAnnotationRanges)[, 
                                                                      c("TXNAME", "GENEID", "eqClass", "newTxClass","readCount", "txNDR")]
   return(extendedAnnotationRanges)


### PR DESCRIPTION
In rare situations where the data had too few reads, the annotations were poor or the NDR threshold was too low  and not a single novel annotation was identified, bambu would crash with this error message. 
`'seqlevels(seqinfo(x))' and 'levels(seqnames(x))' are not identical`
This fix skips the problematic part of the code if no novel annotations are detected.