### PR TITLE
add unit test for writeBambuOutput and update bambu output

### DIFF
--- a/R/bambu-processReads.R
+++ b/R/bambu-processReads.R
@@ -16,7 +16,7 @@
 bambu.processReads <- function(reads, annotations, genomeSequence,
     readClass.outputDir=NULL, yieldSize=1000000, bpParameters, 
     stranded=FALSE, verbose=FALSE, isoreParameters = setIsoreParameters(NULL),
-    lowMemory=FALSE) {
+    lowMemory=FALSE, trackReads=FALSE, fusionMode=FALSE) {
     # ===# create BamFileList object from character #===#
     if (is(reads, "BamFile")) {
         if (!is.null(yieldSize)) {

--- a/tests/testthat/test_readWrite.R
+++ b/tests/testthat/test_readWrite.R
@@ -1,5 +1,31 @@
 context("Generate GTF file from summarizedExperiment object")
 
+# test for the function: writeBambuOutput
+test_that("the output files have correct prefix, file format and all of them are placed correctly in the given output path", {
+    se <- readRDS(system.file("extdata", "seOutput_SGNex_A549_directRNA_replicate5_run1_chr9_1_1000000.rds", package = "bambu"))
+    gtf.file <- system.file("extdata", "Homo_sapiens.GRCh38.91_chr9_1_1000000.gtf", package = "bambu")
+    path <- test_path("fixtures")
+    prefix <- "replicate5_run1_"
+    
+    writeBambuOutput(se, path, prefix)
+    
+    outputFileName <- c("replicate5_run1_extended_annotations.gtf", "replicate5_run1_counts_transcript.txt",
+                        "replicate5_run1_counts_transcript.txt", "replicate5_run1_CPM_transcript.txt", 
+                        "replicate5_run1_fullLengthCounts_transcript.txt", "replicate5_run1_partialLengthCounts_transcript.txt", 
+                        "replicate5_run1_uniqueCounts_transcript.txt", "replicate5_run1_counts_gene.txt")
+    
+    checkOutput <- sapply(outputFileName, function(name){return(file.exists(test_path("fixtures", name)))}) 
+    
+    expect_true(all(checkOutput)) # check prefix and file format 
+    
+    expect_equal(length(list.files(test_path("fixtures"))), 8) # check number of output files at desired output path.
+    
+    unlink(test_path("fixtures", "*"))
+    
+})
+
+
+# test for the function: readFromGTF
 test_that("readGTF can generate a GRangesList from a GTF file", {
     se <- readRDS(system.file("extdata", "seOutput_SGNex_A549_directRNA_replicate5_run1_chr9_1_1000000.rds", package = "bambu"))
     gtf.file <- system.file("extdata", "Homo_sapiens.GRCh38.91_chr9_1_1000000.gtf", package = "bambu")

--- a/tests/testthat/test_readWrite.R
+++ b/tests/testthat/test_readWrite.R
@@ -13,11 +13,11 @@ test_that("the output files of writeBambuOutput have correct prefix, file format
                         "replicate5_run1_fullLengthCounts_transcript.txt", "replicate5_run1_partialLengthCounts_transcript.txt", 
                         "replicate5_run1_uniqueCounts_transcript.txt", "replicate5_run1_counts_gene.txt")
     
-    checkOutput <- outputFileName %in% list.files(test_path('fixtures'))
+    checkOutput <- outputFileName %in% list.files(path)
         
     expect_true(all(checkOutput)) # check prefix and file format 
     
-    expect_equal(length(list.files(test_path("fixtures"))), 8) # check number of output files at desired output path.
+    expect_equal(length(list.files(path)), 8) # check number of output files at desired output path.
     
     unlink(test_path("fixtures", "*"))
     

--- a/tests/testthat/test_readWrite.R
+++ b/tests/testthat/test_readWrite.R
@@ -3,7 +3,6 @@ context("Generate GTF file from summarizedExperiment object")
 # test for the function: writeBambuOutput
 test_that("the output files have correct prefix, file format and all of them are placed correctly in the given output path", {
     se <- readRDS(system.file("extdata", "seOutput_SGNex_A549_directRNA_replicate5_run1_chr9_1_1000000.rds", package = "bambu"))
-    gtf.file <- system.file("extdata", "Homo_sapiens.GRCh38.91_chr9_1_1000000.gtf", package = "bambu")
     path <- test_path("fixtures")
     prefix <- "replicate5_run1_"
     

--- a/tests/testthat/test_readWrite.R
+++ b/tests/testthat/test_readWrite.R
@@ -1,7 +1,7 @@
 context("Generate GTF file from summarizedExperiment object")
 
 # test for the function: writeBambuOutput
-test_that("the output files have correct prefix, file format and all of them are placed correctly in the given output path", {
+test_that("the output files of writeBambuOutput have correct prefix, file format and all of them are placed correctly in the given output path", {
     se <- readRDS(system.file("extdata", "seOutput_SGNex_A549_directRNA_replicate5_run1_chr9_1_1000000.rds", package = "bambu"))
     path <- test_path("fixtures")
     prefix <- "replicate5_run1_"
@@ -13,8 +13,8 @@ test_that("the output files have correct prefix, file format and all of them are
                         "replicate5_run1_fullLengthCounts_transcript.txt", "replicate5_run1_partialLengthCounts_transcript.txt", 
                         "replicate5_run1_uniqueCounts_transcript.txt", "replicate5_run1_counts_gene.txt")
     
-    checkOutput <- sapply(outputFileName, function(name){return(file.exists(test_path("fixtures", name)))}) 
-    
+    checkOutput <- outputFileName %in% list.files(test_path('fixtures'))
+        
     expect_true(all(checkOutput)) # check prefix and file format 
     
     expect_equal(length(list.files(test_path("fixtures"))), 8) # check number of output files at desired output path.
@@ -22,7 +22,6 @@ test_that("the output files have correct prefix, file format and all of them are
     unlink(test_path("fixtures", "*"))
     
 })
-
 
 # test for the function: readFromGTF
 test_that("readGTF can generate a GRangesList from a GTF file", {


### PR DESCRIPTION
Here I add some unit tests for the writeBambuOutput() function. 
It tests whether: 
- the prefix is as expected 
- the output files go to the correct output path
- the file extensions are correct
- the column names for the count outputs include "GENEID" and/or "TXNAME".
- the sample columns for count output files are numeric.

Additionally,  since the theta column was removed from the Bambu output, some of the internal/external data would also need to be updated. 
