### PR TITLE
Unit test and documentation for function: compareTranscripts

### DIFF
--- a/R/compareTranscripts.R
+++ b/R/compareTranscripts.R
@@ -56,19 +56,19 @@
 #'     subject transcript, -k if the query transcript ends the transcription k sites earlier than the 
 #'     subject transcript. 
 #'     \item internalLastExon.query: TRUE if the last exon of the query transcript is equivalent to one 
-#'     of the exon in the subject transcript (except the first exon). FALSE otherwise. 
+#'     of the exon in the subject transcript (except the last exon). FALSE otherwise. 
 #'     \item internalLastExon.subject: TRUE if the last exon of the subject transcript is equivalent to 
-#'     one of the exon in the query transcript (except the first exon). FALSE otherwise. 
-#'     \item intronRetention.subject: k if there is/are k introns in the subject transcript relative to the 
+#'     one of the exon in the query transcript (except the last exon). FALSE otherwise. 
+#'     \item intronRetention.subject: k if there is/are k intron(s) in the subject transcript relative to the 
 #'     query transcript. 
-#'     \item intronRetention.query: k if there is/are k introns in the query transcript relative to the 
+#'     \item intronRetention.query: k if there is/are k intron(s) in the query transcript relative to the 
 #'     subject transcript. 
-#'     \item exonSkipping.query: k if there is/are k equivalent exons in the subject transcript not in the
+#'     \item exonSkipping.query: k if there is/are k exon(s) in the subject transcript (except the first and last) not in the
 #'     query transcript. 
-#'     \item exonSkipping.subject: k if there is/are k equivalent exons in the query transcript not in the 
+#'     \item exonSkipping.subject: k if there is/are k exon(s) in the query transcript (except the first and last) not in the 
 #'     subject transcript. 
-#'     \item exon5prime (splicing): k if there is/are k equivalent exons having different 5' start site. 
-#'     \item exon3prime (splicing): k if there is/are k equivalent exons having different 3' end site.
+#'     \item exon5prime (splicing): k if there is/are k equivalent exon(s) having different 5' start site (except the 5' start site of first exon).
+#'     \item exon3prime (splicing): k if there is/are k equivalent exon(s) having different 3' end site (except the 3' end site of the last exon).
 #' }
 #' @importFrom dplyr tibble 
 #' @examples

--- a/R/compareTranscripts.R
+++ b/R/compareTranscripts.R
@@ -3,7 +3,7 @@
 # 'ENST00000344579', # exon skipping, alternative TSS (-48), +, ENSG00000158109
 # 'ENST00000270792', # intron retention subject 1(last exon),alt.TSS,alt.TES, +,
 # 'ENST00000410032', # alternative first exon, exon skipping query: 2, 
-#                    # exon skipping subject: 0, alternative TSS (2bp only), 
+#                    # exon skipping subject: 0, alternative TES (2bp only), 
 #                    # internalFirstExon.subject +
 # 'ENST00000468178', # alternative last exon +
 # 'ENST00000485956', # alternative first exon, alternative last exon,
@@ -24,30 +24,51 @@
 #        package = "bambu"))
 ############################################################
 
-#' annotate splice overlap by distance
-#' @description This function takes in a GRangesList (query)
-#' and a target GRangesList (subject). The function creates
-#' an annotation table in tibble by comparing ranges entries
-#' from transcripts between the query and subject GRangesLists.
-#' @usage compareTranscripts(query, subject)
-#' @param query a GRangesList
-#' @param subject a GRangesList
-#' @return a tibble with the following annotations:
+#' @title compare alternatively-spliced transcripts
+#' @param query a GRangesList of transcripts
+#' @param subject a GRangesList of transcripts
+#' @details This function compares two alternatively-spliced transcripts and returns 
+#' a \code{tibble} object that determines the type of the alternative splicing between 
+#' the query and the subject transcript. Alternative splicing includes exons skipping, 
+#' intron retention, alternative 5' exon start site, alternative 3' exon end site, alternative
+#' first exon, alternative last exon, alternative transcription start site (TSS), 
+#' alternative transcription end site (TES), internal first exon, internal last exon, or a 
+#' mixed combination of them. 
+#' @seealso \code{Value} for more details about each of the alternative splicing events. 
+#' @return a \code{tibble} object with the following columns:
+#' 
+#' Remark: two exons, one each from query and subject transcript are defined to be equivalent if one of 
+#' the exons fully covers the another exon. 
+#' 
 #' \itemize{
-#'     \item alternativeFirstExon
-#'     \item alternativeTSS
-#'     \item internalFirstExon.query
-#'     \item internalFirstExon.subject
-#'     \item alternativeLastExon
-#'     \item alternativeTES
-#'     \item internalLastExon.query
-#'     \item internalLastExon.subject
-#'     \item intronRetention.subject
-#'     \item intronRetention.query
-#'     \item exonSkipping.query
-#'     \item exonSkipping.subject
-#'     \item exon5prime (splicing)
-#'     \item exon3prime (splicing)
+#'     \item alternativeFirstExon: FALSE if query transcript and subject transcript have equivalent
+#'     first exon. TRUE otherwise. 
+#'     \item alternativeTSS: +k if the query initiates the transcription k sites earlier 
+#'     than the subject transcript, -k if the query initiates the transcription k sites later 
+#'     than the subject transcript. 
+#'     \item internalFirstExon.query: TRUE if the first exon of the query transcript is equivalent to
+#'     one of the exon of the subject transcript (except the first exon). FALSE otherwise. 
+#'     \item internalFirstExon.subject: TRUE if the first exon of the subject transcript is equivalent to
+#'     one of the exon of the query transcript (except the first exon). FALSE otherwise. 
+#'     \item alternativeLastExon: FALSE if query transcript and subject transcript have equivalent last
+#'     exon. TRUE otherwise. 
+#'     \item alternativeTES: +k if the query transcript ends the transcription k sites later than the 
+#'     subject transcript, -k if the query transcript ends the transcription k sites earlier than the 
+#'     subject transcript. 
+#'     \item internalLastExon.query: TRUE if the last exon of the query transcript is equivalent to one 
+#'     of the exon in the subject transcript (except the first exon). FALSE otherwise. 
+#'     \item internalLastExon.subject: TRUE if the last exon of the subject transcript is equivalent to 
+#'     one of the exon in the query transcript (except the first exon). FALSE otherwise. 
+#'     \item intronRetention.subject: k if there is/are k introns in the subject transcript relative to the 
+#'     query transcript. 
+#'     \item intronRetention.query: k if there is/are k introns in the query transcript relative to the 
+#'     subject transcript. 
+#'     \item exonSkipping.query: k if there is/are k equivalent exons in the subject transcript not in the
+#'     query transcript. 
+#'     \item exonSkipping.subject: k if there is/are k equivalent exons in the query transcript not in the 
+#'     subject transcript. 
+#'     \item exon5prime (splicing): k if there is/are k equivalent exons having different 5' start site. 
+#'     \item exon3prime (splicing): k if there is/are k equivalent exons having different 3' end site.
 #' }
 #' @importFrom dplyr tibble 
 #' @examples
@@ -57,7 +78,9 @@
 #' subject <- readRDS(system.file("extdata", 
 #'     "annotateSpliceOverlapByDist_testSubject.rds",
 #'     package = "bambu"))
-#' annotationTable <- compareTranscripts(query, subject)
+#' compareTranscriptsTable <- compareTranscripts(query, subject)
+#' 
+#' compareTranscriptsTable
 #' @noRd
 compareTranscripts <- function(query, subject) {
     subjectFullRng <- ranges(subject)

--- a/tests/testthat/test_compareTranscripts.R
+++ b/tests/testthat/test_compareTranscripts.R
@@ -1,10 +1,225 @@
 context("annotate splice overlap by distance")
 
-test_that("annotateSpliceOverlapByDist can generate a dataframe with annotation",{
-  query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
-  subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
-  refTab <- readRDS(system.file("extdata", "annotateSpliceOverlapsByDist_refoutput.rds", package = "bambu"))
-  tab <- compareTranscripts(query, subject)
-  expect_is(tab, class = 'data.frame')
-  expect_equal(tab, refTab[, colnames(tab)])
+test_that("compareTranscripts between the query transcripts and subject transcripts match the expectations",{
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    refTab <- readRDS(system.file("extdata", "annotateSpliceOverlapsByDist_refoutput.rds", package = "bambu"))
+  
+    expect_is(tab, class = 'data.frame')
+    expect_equal(refTab, tab)
 })
+
+# For the remaining of the test, we select a few test case to validate the output from the 
+# compareTranscripts function. These test cases are selected in a way to cover as
+# many scenarios as possible. 
+
+test_that("compareTranscripts gives correct output about exon skipping (query) 
+          and alternative TSS for a transcript along positive strand", {
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[1]
+    t2 <- subject[1]
+    
+    # check alternative TSS
+    expect_equal(tab[1,]$alternativeTSS, -(3625050 - 3625015)) 
+    
+    # check exon skipping (query)
+    expect_equal(tab[1,]$exonSkipping.query, 1) 
+    
+})
+
+
+test_that("compareTranscripts gives correct output about intron retention (subject), 
+          alternative TSS and alternative TES for a transcript along positive strand", {
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[2]
+    t2 <- subject[2]
+    
+    # check alternative TSS
+    expect_equal(tab[2,]$alternativeTSS, -(26280086 - 26280122))
+    
+    # check alternative TES 
+    expect_equal(tab[2,]$alternativeTES, 26281522 - 26281450)
+    
+    # check intron retention (subject)
+    expect_equal(tab[2,]$intronRetention.subject, 1)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about alternative first exon, exon skipping (query), 
+          exon skipping (subject), alternative TSS and internalFirstExon (subject) for a transcript along positive strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[3]
+    t2 <- subject[3]
+
+    # check alternative first exon 
+    expect_equal(tab[3,]$alternativeFirstExon, TRUE)
+    
+    # check alternative TES 
+    expect_equal(tab[3,]$alternativeTES, 237553996 - 237553994)
+    
+    # check internal first exon (subject)
+    expect_equal(tab[3,]$internalFirstExon.subject, TRUE)
+
+    # check exon skipping (query)
+    expect_equal(tab[3,]$exonSkipping.query, 2)
+    
+    # check exon skipping (subject)
+    expect_equal(tab[3,]$exonSkipping.subject, 0)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about alternative last exons and intron retention (query) for a transcript along positive strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[4]
+    t2 <- subject[4]
+    
+    # check alternative last exons 
+    expect_equal(tab[4,]$alternativeLastExon, TRUE)
+    
+    # check intron retention (query)
+    expect_equal(tab[4, ]$intronRetention.query, 0)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about alternative first exon, alternative last exon, 
+          exon skipping (subject) and internal first exon (query) for a transcript along positive strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[5]
+    t2 <- subject[5]
+    
+    # check alternative first exon 
+    expect_equal(tab[5,]$alternativeFirstExon, TRUE)
+    
+    # check alternative last exon 
+    expect_equal(tab[5,]$alternativeLastExon, TRUE)
+    
+    # check exon skipping (subject)
+    expect_equal(tab[5,]$exonSkipping.subject, 1)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about exon skipping (query) and 
+          alternative TSS for a transcript along negative strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[6]
+    t2 <- subject[6]
+
+    # check exon skipping (query)
+    expect_equal(tab[6,]$exonSkipping.query, 1)
+    
+    # check alternative TSS
+    expect_equal(tab[6,]$alternativeTSS, 144413569 - 144413586)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about alternative 3' exon splice site, exon skipping (query), 
+          alternative TSS and alternative TES for a transcript along positive strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[7]
+    t2 <- subject[7]
+
+    # check exon skipping (query)
+    expect_equal(tab[7,]$exonSkipping.query, 2)
+    
+    # check alternative TSS 
+    expect_equal(tab[7,]$alternativeTSS, -(112542226 - 112541915))
+    
+    # check alternative TES
+    expect_equal(tab[7,]$alternativeTES, 112577058 - 112576299)
+    
+    # check alternative 3' exon splice site
+    expect_equal(tab[7,]$exon3Prime, 1)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about alternative TSS, alternative last exon, internal last exon (query), 
+          alternative exon 3' end and alternative exon 5' end for a transcript along negative strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[8]
+    t2 <- subject[8]
+    
+    # check alternative TSS
+    expect_equal(tab[8,]$alternativeTSS, 47426225 - 47426266)
+    
+    # check alternative last exon
+    expect_equal(tab[8,]$alternativeLastExon, TRUE)
+    
+    # check internal last exon
+    expect_equal(tab[8,]$internalLastExon.query, TRUE)
+    
+    # check alternative 3' exon splice site
+    expect_equal(tab[8,]$exon3Prime, 1)
+    
+    # check alternative 5' exon splice site
+    expect_equal(tab[8,]$exon5Prime, 0)
+    
+})
+
+
+test_that("compareTranscripts gives correct output about alternative TSS, alternative exon 3' end, 
+          alternative exon 5' end and alternative TES for a transcript along positive strand", {
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    # transcripts to inspect & compare
+    t1 <- query[9]
+    t2 <- subject[9]
+    
+    # check alternative TSS 
+    expect_equal(tab[9,]$alternativeTSS, -(44070892 - 44070751))
+    
+    # check alternative TES 
+    expect_equal(tab[9,]$alternativeTES, 44075841 - 44076300)
+    
+    # check alternative 3' exon splice site 
+    expect_equal(tab[9,]$exon3Prime, 2)
+    
+    # check alternative 5' exon splice site
+    expect_equal(tab[9,]$exon5Prime, 1)
+    
+})
+    

--- a/tests/testthat/test_compareTranscripts.R
+++ b/tests/testthat/test_compareTranscripts.R
@@ -13,213 +13,187 @@ test_that("compareTranscripts between the query transcripts and subject transcri
 })
 
 # For the remaining of the test, we select a few test case to validate the output from the 
-# compareTranscripts function. These test cases are selected in a way to cover as
-# many scenarios as possible. 
+# compareTranscripts function. They are selected in a way to capture as many scenarios as possible.
+# These test cases are shown below. 
 
-test_that("compareTranscripts gives correct output about exon skipping (query) 
-          and alternative TSS for a transcript along positive strand", {
+### examples for test purposes
+## Expected annotations of transcripts used in test query
+# 'ENST00000344579', # exon skipping, alternative TSS (-35), +, ENSG00000158109
+# 'ENST00000270792', # intron retention subject 1(last exon),alt.TSS,alt.TES, +,
+# 'ENST00000410032', # alternative first exon, exon skipping query: 2, 
+#                    # exon skipping subject: 0, alternative TES (2bp only), 
+#                    # internalFirstExon.subject +
+# 'ENST00000468178', # alternative last exon +
+# 'ENST00000485956', # alternative first exon, alternative last exon,
+# #exon skipping subject = 1, internal first exon query, +
+# 'ENST00000530807', # exon skipping query 1, alternative TSS (-17),  -
+# 'ENST00000409894', # alternative 3' exon splice site, exon skipping query 2,
+# #alternative TSS, alterantive TES, +, ENSG00000125630
+# 'ENST00000524447',  # alternative TSS, alternative last exon (internal), 
+# #alternative exon 3' end,-, ENSG00000165916
+# 'ENST00000591696' # alternative TSS, alternative 3' exon (2), 
+# #alternative 5' exon (1) alternative TES, ,+,ENSG00000141349
+
+test_that("the strand column of compareTranscripts matches the expectations",{
     
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[1]
-    t2 <- subject[1]
-    
-    # check alternative TSS
-    expect_equal(tab[1,]$alternativeTSS, -(3625050 - 3625015)) 
-    
-    # check exon skipping (query)
-    expect_equal(tab[1,]$exonSkipping.query, 1) 
+    expect_equal(tab$strand, c("+", "+", "+", "+", "+", "-", "+", "-", "+"))
     
 })
 
 
-test_that("compareTranscripts gives correct output about intron retention (subject), 
-          alternative TSS and alternative TES for a transcript along positive strand", {
+test_that("the alternativeFirstExon column of compareTranscripts matches the expectations",{
+  
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    expect_equal(tab$alternativeFirstExon, c(FALSE, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE))
+    
+})
+
+
+test_that("the alternativeTSS column of compareTranscripts matches the expectations",{
     
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[2]
-    t2 <- subject[2]
-    
-    # check alternative TSS
-    expect_equal(tab[2,]$alternativeTSS, -(26280086 - 26280122))
-    
-    # check alternative TES 
-    expect_equal(tab[2,]$alternativeTES, 26281522 - 26281450)
-    
-    # check intron retention (subject)
-    expect_equal(tab[2,]$intronRetention.subject, 1)
+    expect_equal(tab$alternativeTSS, c(-35, 36, 0, 0, 0, -17, -311, -41, -141))
     
 })
 
 
-test_that("compareTranscripts gives correct output about alternative first exon, exon skipping (query), 
-          exon skipping (subject), alternative TSS and internalFirstExon (subject) for a transcript along positive strand", {
+test_that("the internalFirstExon.query column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[3]
-    t2 <- subject[3]
-
-    # check alternative first exon 
-    expect_equal(tab[3,]$alternativeFirstExon, TRUE)
-    
-    # check alternative TES 
-    expect_equal(tab[3,]$alternativeTES, 237553996 - 237553994)
-    
-    # check internal first exon (subject)
-    expect_equal(tab[3,]$internalFirstExon.subject, TRUE)
-
-    # check exon skipping (query)
-    expect_equal(tab[3,]$exonSkipping.query, 2)
-    
-    # check exon skipping (subject)
-    expect_equal(tab[3,]$exonSkipping.subject, 0)
+    expect_equal(as.logical(tab$internalFirstExon.query), c(FALSE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE))
     
 })
 
 
-test_that("compareTranscripts gives correct output about alternative last exons and intron retention (query) for a transcript along positive strand", {
+test_that("the internalFirstExon.subject column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[4]
-    t2 <- subject[4]
-    
-    # check alternative last exons 
-    expect_equal(tab[4,]$alternativeLastExon, TRUE)
-    
-    # check intron retention (query)
-    expect_equal(tab[4, ]$intronRetention.query, 0)
+    expect_equal(as.logical(tab$internalFirstExon.subject), c(FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE))
     
 })
 
 
-test_that("compareTranscripts gives correct output about alternative first exon, alternative last exon, 
-          exon skipping (subject) and internal first exon (query) for a transcript along positive strand", {
+test_that("the alternativeLastExon column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[5]
-    t2 <- subject[5]
-    
-    # check alternative first exon 
-    expect_equal(tab[5,]$alternativeFirstExon, TRUE)
-    
-    # check alternative last exon 
-    expect_equal(tab[5,]$alternativeLastExon, TRUE)
-    
-    # check exon skipping (subject)
-    expect_equal(tab[5,]$exonSkipping.subject, 1)
+    expect_equal(tab$alternativeLastExon, c(FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE))
     
 })
 
 
-test_that("compareTranscripts gives correct output about exon skipping (query) and 
-          alternative TSS for a transcript along negative strand", {
+test_that("the alternativeTES column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[6]
-    t2 <- subject[6]
-
-    # check exon skipping (query)
-    expect_equal(tab[6,]$exonSkipping.query, 1)
-    
-    # check alternative TSS
-    expect_equal(tab[6,]$alternativeTSS, 144413569 - 144413586)
+    expect_equal(tab$alternativeTES, c(0, 72, 2, 0, 0, 0, 759, 0, -459))
     
 })
 
 
-test_that("compareTranscripts gives correct output about alternative 3' exon splice site, exon skipping (query), 
-          alternative TSS and alternative TES for a transcript along positive strand", {
+test_that("the internalLastExon.query column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[7]
-    t2 <- subject[7]
-
-    # check exon skipping (query)
-    expect_equal(tab[7,]$exonSkipping.query, 2)
-    
-    # check alternative TSS 
-    expect_equal(tab[7,]$alternativeTSS, -(112542226 - 112541915))
-    
-    # check alternative TES
-    expect_equal(tab[7,]$alternativeTES, 112577058 - 112576299)
-    
-    # check alternative 3' exon splice site
-    expect_equal(tab[7,]$exon3Prime, 1)
+    expect_equal(as.logical(tab$internalLastExon.query), c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE))
     
 })
 
 
-test_that("compareTranscripts gives correct output about alternative TSS, alternative last exon, internal last exon (query), 
-          alternative exon 3' end and alternative exon 5' end for a transcript along negative strand", {
+test_that("the internalLastExon.subject column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[8]
-    t2 <- subject[8]
-    
-    # check alternative TSS
-    expect_equal(tab[8,]$alternativeTSS, 47426225 - 47426266)
-    
-    # check alternative last exon
-    expect_equal(tab[8,]$alternativeLastExon, TRUE)
-    
-    # check internal last exon
-    expect_equal(tab[8,]$internalLastExon.query, TRUE)
-    
-    # check alternative 3' exon splice site
-    expect_equal(tab[8,]$exon3Prime, 1)
-    
-    # check alternative 5' exon splice site
-    expect_equal(tab[8,]$exon5Prime, 0)
+    expect_equal(as.logical(tab$internalLastExon.subject), c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE))
     
 })
 
 
-test_that("compareTranscripts gives correct output about alternative TSS, alternative exon 3' end, 
-          alternative exon 5' end and alternative TES for a transcript along positive strand", {
+test_that("the intronRetention.subject column of compareTranscripts matches the expectations",{
+    
     query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
     subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
     tab <- compareTranscripts(query, subject)
     
-    # transcripts to inspect & compare
-    t1 <- query[9]
-    t2 <- subject[9]
-    
-    # check alternative TSS 
-    expect_equal(tab[9,]$alternativeTSS, -(44070892 - 44070751))
-    
-    # check alternative TES 
-    expect_equal(tab[9,]$alternativeTES, 44075841 - 44076300)
-    
-    # check alternative 3' exon splice site 
-    expect_equal(tab[9,]$exon3Prime, 2)
-    
-    # check alternative 5' exon splice site
-    expect_equal(tab[9,]$exon5Prime, 1)
+    expect_equal(as.numeric(tab$intronRetention.subject), c(0, 1, 0, 0, 0, 0, 0, 0, 0))
     
 })
+
+
+test_that("the intronRetention.query column of compareTranscripts matches the expectations",{
     
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    expect_equal(as.numeric(tab$intronRetention.query), c(0, 0, 0, 0, 0, 0, 0, 0, 0))
+    
+})
+
+
+test_that("the exonSkipping.query column of compareTranscripts matches the expectations",{
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    expect_equal(tab$exonSkipping.query, c(1, 0, 2, 0, 0, 1, 2, 0, 0))
+    
+})
+
+
+test_that("the exonSkipping.subject column of compareTranscripts matches the expectations",{
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    expect_equal(tab$exonSkipping.subject, c(0, 0, 0, 0, 1, 0, 0, 0, 0))
+    
+})
+
+
+test_that("the exon5Prime column of compareTranscripts matches the expectations",{
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    expect_equal(as.numeric(tab$exon5Prime), c(0, 0, 0, 0, 0, 0, 0, 0, 1))
+    
+})
+
+
+test_that("the exon3Prime column of compareTranscripts matches the expectations",{
+    
+    query <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testQuery.rds", package = "bambu"))
+    subject <- readRDS(system.file("extdata", "annotateSpliceOverlapByDist_testSubject.rds", package = "bambu"))
+    tab <- compareTranscripts(query, subject)
+    
+    expect_equal(as.numeric(tab$exon3Prime), c(0, 0, 0, 0, 0, 0, 1, 1, 2))
+    
+})


### PR DESCRIPTION
In this pull request: 

- more unit tests are added to check for different cases of alternative splicing in the `compareTranscripts` function.
- a more complete documentation of the `compareTranscripts` function is added. 