### PR TITLE
Windows genome bug

### DIFF
--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -155,16 +155,9 @@ checkInputSequence <- function(genomeSequence) {
     } 
     tryCatch(
     {
-        if (.Platform$OS.type == "windows") {
-        genomeSequence <- Biostrings::readDNAStringSet(genomeSequence)
-        newlevels <- unlist(lapply(strsplit(names(genomeSequence)," "),
-                                    "[[", 1))
-        names(genomeSequence) <- newlevels
-        } else {
         indexFileExists <- file.exists(paste0(genomeSequence,".fai"))
         if (!indexFileExists) indexFa(genomeSequence)
         genomeSequence <- FaFile(genomeSequence)
-        }
     },
     error=function(cond) {
         stop("Input genome file not readable.",

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ BiocManager::install("bambu")
 GitHub:
 ```rscript
 library(devtools)
-load_github("GoekeLab/bambu")
+install_github("GoekeLab/bambu")
 library(bambu)
 ```
 We can test if *bambu* is installed correctly and runs correctly by using a small test set that comes with the package. 


### PR DESCRIPTION
three tests were failing when running on a windows machine.
This was due to a different method used to import the genome on windows that were not compatible with downstream functions.
The windows specific import seems no longer needed with latest packages.