### PR TITLE
reduce memory and speed up assignGeneId from issue #368

### DIFF
--- a/R/bambu-processReads_utilityConstructReadClasses.R
+++ b/R/bambu-processReads_utilityConstructReadClasses.R
@@ -439,8 +439,7 @@ assignGeneIdsByReference <- function(grl, annotations, min.exonOverlap = 10,
     uniqueHits <- which(queryHits(ov) %in% which(countQueryHits(ov)==1))
     geneIds[queryHits(ov)[uniqueHits]] <- 
         names(geneRanges)[subjectHits(ov)[uniqueHits]]
-    
-    if(length(multiHits)>0){
+    if(length(ov)>0){
         ## next for non unique hits select one gene (maximum overlap)
         multiHits <- which(queryHits(ov) %in% which(countQueryHits(ov)>1))
         rangeIntersect= intersect(ranges(grl[queryHits(ov)[multiHits]]),

--- a/R/bambu-processReads_utilityConstructReadClasses.R
+++ b/R/bambu-processReads_utilityConstructReadClasses.R
@@ -382,10 +382,12 @@ assignGeneIds <-  function(grl, annotations, min.exonOverlap = 10, fusionMode = 
                                           fusionMode = fusionMode) 
     #iteratively assign gene ids for stranded granges
     newGeneSet <- is.na(mcols(grl)$GENEID) & strandedRanges
-    referenceGeneSet <- !is.na(mcols(grl)$GENEID) & strandedRanges
-    mcols(grl)$GENEID[newGeneSet] <- assignGeneIdsByReference(grl[newGeneSet], grl[referenceGeneSet],
-                                                                  min.exonOverlap = min.exonOverlap,
-                                                                  fusionMode = FALSE)  # fusion assignment is only done based on original annotations
+    if(sum(newGeneSet != 0)){
+        referenceGeneSet <- !is.na(mcols(grl)$GENEID) & strandedRanges
+        mcols(grl)$GENEID[newGeneSet] <- assignGeneIdsByReference(grl[newGeneSet], grl[referenceGeneSet],
+                                                                    min.exonOverlap = min.exonOverlap,
+                                                                    fusionMode = FALSE)  # fusion assignment is only done based on original annotations
+    }
     chainCount <- 1  # first iteration is outside of while loop
     while(any(!is.na(mcols(grl)$GENEID[newGeneSet])) & chainCount < maxChainIteration) {
       referenceGeneSet <- newGeneSet & !is.na(mcols(grl)$GENEID) & strandedRanges
@@ -438,31 +440,31 @@ assignGeneIdsByReference <- function(grl, annotations, min.exonOverlap = 10,
     geneIds[queryHits(ov)[uniqueHits]] <- 
         names(geneRanges)[subjectHits(ov)[uniqueHits]]
     
-    ## next for non unique hits select one gene (maximum overlap)
-    multiHits <- which(queryHits(ov) %in% which(countQueryHits(ov)>1))
-    rangeIntersect= intersect(ranges(grl[queryHits(ov)[multiHits]]),
-                                ranges(geneRanges[subjectHits(ov)[multiHits]]))
-    filteredMultiHits =  data.frame(queryHits = queryHits(ov)[multiHits], 
-                                    intersectWidth = sum(width(rangeIntersect)), 
-                                    subjectHits = subjectHits(ov)[multiHits]) %>% 
-        group_by(queryHits) %>% summarise(subjectHits = subjectHits[which.max(intersectWidth)],
-                                                intersectWidth = max(intersectWidth))
-    filteredMultiHits <- as_tibble(ov[multiHits]) %>% 
-        mutate(intersectWidth = intersectById)
-    if(fusionMode) {
-      filteredMultiHits <- filteredMultiHits %>%  
-        filter(intersectWidth>min.exonOverlap) %>%  
-        mutate(geneid = names(geneRanges)[subjectHits]) %>%  distinct() %>% 
-        group_by(queryHits) %>% summarise(geneid = paste(geneid, collapse=':'))
-      geneIds[filteredMultiHits$queryHits] <- filteredMultiHits$geneid
-      
-    } else {
-    filteredMultiHits <- filteredMultiHits %>% 
-        group_by(queryHits) %>% arrange(desc(intersectWidth)) %>% 
-        dplyr::slice(1)
-    geneIds[filteredMultiHits$queryHits] <- 
-        names(geneRanges)[filteredMultiHits$subjectHits]
-    } 
+    if(length(multiHits)>0){
+        ## next for non unique hits select one gene (maximum overlap)
+        multiHits <- which(queryHits(ov) %in% which(countQueryHits(ov)>1))
+        rangeIntersect= intersect(ranges(grl[queryHits(ov)[multiHits]]),
+                                    ranges(geneRanges[subjectHits(ov)[multiHits]]))
+        filteredMultiHits =  data.frame(queryHits = queryHits(ov)[multiHits], 
+                                        intersectWidth = sum(width(rangeIntersect)), 
+                                        subjectHits = subjectHits(ov)[multiHits]) %>% 
+            group_by(queryHits) %>% summarise(subjectHits = subjectHits[which.max(intersectWidth)],
+                                                    intersectWidth = max(intersectWidth))
+        if(fusionMode) {
+        filteredMultiHits <- filteredMultiHits %>%  
+            filter(intersectWidth>min.exonOverlap) %>%  
+            mutate(geneid = names(geneRanges)[subjectHits]) %>%  distinct() %>% 
+            group_by(queryHits) %>% summarise(geneid = paste(geneid, collapse=':'))
+        geneIds[filteredMultiHits$queryHits] <- filteredMultiHits$geneid
+        
+        } else {
+        filteredMultiHits <- filteredMultiHits %>% 
+            group_by(queryHits) %>% arrange(desc(intersectWidth)) %>% 
+            dplyr::slice(1)
+        geneIds[filteredMultiHits$queryHits] <- 
+            names(geneRanges)[filteredMultiHits$subjectHits]
+        } 
+    }
     return(geneIds)
 }
 

--- a/R/bambu-processReads_utilityConstructReadClasses.R
+++ b/R/bambu-processReads_utilityConstructReadClasses.R
@@ -440,13 +440,13 @@ assignGeneIdsByReference <- function(grl, annotations, min.exonOverlap = 10,
     
     ## next for non unique hits select one gene (maximum overlap)
     multiHits <- which(queryHits(ov) %in% which(countQueryHits(ov)>1))
-    expandedRanges <- expandRangesList(ranges(grl[queryHits(ov)[multiHits]]),
-        ranges(geneRanges[subjectHits(ov)[multiHits]]))
-    rangeIntersect <- pintersect(expandedRanges, 
-        mcols(expandedRanges)$matchRng, resolve.empty = 'start.x')
-    intersectById <- tapply(width(rangeIntersect), 
-                            mcols(expandedRanges)$IdMap, sum)
-    
+    rangeIntersect= intersect(ranges(grl[queryHits(ov)[multiHits]]),
+                                ranges(geneRanges[subjectHits(ov)[multiHits]]))
+    filteredMultiHits =  data.frame(queryHits = queryHits(ov)[multiHits], 
+                                    intersectWidth = sum(width(rangeIntersect)), 
+                                    subjectHits = subjectHits(ov)[multiHits]) %>% 
+        group_by(queryHits) %>% summarise(subjectHits = subjectHits[which.max(intersectWidth)],
+                                                intersectWidth = max(intersectWidth))
     filteredMultiHits <- as_tibble(ov[multiHits]) %>% 
         mutate(intersectWidth = intersectById)
     if(fusionMode) {


### PR DESCRIPTION
No longer creates the large expandedRanges object that caused crashes with large data sets
Speed up the function by removing the arrange