### PR TITLE
fixing the chunk when showing the import from the TxDb object

### DIFF
--- a/vignettes/bambu.Rmd
+++ b/vignettes/bambu.Rmd
@@ -128,8 +128,9 @@ annotation <- prepareAnnotations(gtf.file)
 ```
 The annotation object can also be created from a TxDb object:
 ```{r}
-txdb <- system.file("extdata", "Homo_sapiens.GRCh38.91_chr9_1_1000000.gtf",
+txdb_file <- system.file("extdata", "Homo_sapiens.GRCh38.91.annotations-txdb_chr9_1_1000000.sqlite",
     package = "bambu")
+txdb <- AnnotationDbi::loadDb(txdb_file)
 annotation <- prepareAnnotations(txdb)
 ```
 


### PR DESCRIPTION
I simply changed the vignette chunk to have it really reading in the TxDb file first and then `loadDb`ing it for using as input to `prepareAnnotations()`