### PR TITLE
Fix typo in extendAnnotations

### DIFF
--- a/R/bambu-extendAnnotations-utilityExtend.R
+++ b/R/bambu-extendAnnotations-utilityExtend.R
@@ -108,7 +108,7 @@ filterTranscriptsByAnnotation <- function(rowDataCombined, annotationGrangesList
     exonRangesCombined <- exonRangesCombined[filterSet]
     rowDataCombined <- rowDataCombined[filterSet,]
   }
-  if(sum(filterSet==0) & length(annotationGrangesList)==0) stop(
+  if(sum(filterSet)==0 & length(annotationGrangesList)==0) stop(
     "WARNING - No annotations were provided. Please increase NDR threshold to use novel transcripts")
   if(sum(filterSet)==0) message("WARNING - No novel transcripts meet the given thresholds. Try a higher NDR.")
   # (3) combine novel transcripts with annotations


### PR DESCRIPTION
Fixes a typo in de novo mode which would cause it to stop prematurely as it was not checking if the number of transcripts left in the filterset == 0, but rather was incorrectly summing filterSet==0. 