### PR TITLE
min.txScore.singleExon bug fix

### DIFF
--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -19,7 +19,7 @@ isore.combineTranscriptCandidates <- function(readClassList,
         min.readCount, min.readFractionByGene, 
         min.txScore.multiExon, min.txScore.singleExon, verbose) %>% data.table()
     combinedSplicedTranscripts[,confidenceType := "highConfidenceJunctionReads"]
-    if (min.txScore.singleExon < 1) {return(combinedSplicedTranscripts)}
+    if (min.txScore.singleExon == 1) {return(combinedSplicedTranscripts)}
     combinedUnsplicedTranscripts <- 
         combineUnsplicedTranscriptModels(readClassList, bpParameters, 
         stranded, min.readCount, min.readFractionByGene, 


### PR DESCRIPTION
Because min.txScore.singleExon always smaller than 1, the function (isore.combineTranscriptCandidates) will always return to combinedSplicedTranscripts and don't combine the unspliced Tx.