### PR TITLE
remove the lowMemory and update example code for generating rcf

### DIFF
--- a/R/bambu-processReads.R
+++ b/R/bambu-processReads.R
@@ -110,6 +110,7 @@ bambu.processReads <- function(reads, annotations, genomeSequence,
                 readClass.outputDir, ask = FALSE),
                 paste0(readClassFile,"_readClassSe"), ext = ".rds")
             saveRDS(readClassList[[i]], file = readClassFile)
+            readClassList[[i]] <- readClassFile
         }
     }
     #TODO don't output list, current there because discovery needs it

--- a/R/bambu-processReads.R
+++ b/R/bambu-processReads.R
@@ -110,7 +110,6 @@ bambu.processReads <- function(reads, annotations, genomeSequence,
                 readClass.outputDir, ask = FALSE),
                 paste0(readClassFile,"_readClassSe"), ext = ".rds")
             saveRDS(readClassList[[i]], file = readClassFile)
-            readClassList[[i]] <- readClassFile
         }
     }
     #TODO don't output list, current there because discovery needs it

--- a/R/bambu-processReads.R
+++ b/R/bambu-processReads.R
@@ -106,16 +106,12 @@ bambu.processReads <- function(reads, annotations, genomeSequence,
     if (!is.null(readClass.outputDir)) {
         for(i in seq_along(readClassList)){
             readClassFile <- "combinedSamples"
-            if(lowMemory){
-                readClassFile <- metadata(readClassList[[i]])$sampleNames
-            }
             readClassFile <- BiocFileCache::bfcnew(BiocFileCache::BiocFileCache(
                 readClass.outputDir, ask = FALSE),
                 paste0(readClassFile,"_readClassSe"), ext = ".rds")
             saveRDS(readClassList[[i]], file = readClassFile)
             readClassList[[i]] <- readClassFile
         }
-        
     }
     #TODO don't output list, current there because discovery needs it
     return(readClassList)

--- a/R/bambu.R
+++ b/R/bambu.R
@@ -138,7 +138,7 @@
 bambu <- function(reads, annotations = NULL, genome = NULL, NDR = NULL,
     mode = NULL, opt.discovery = NULL, opt.em = NULL, rcOutDir = NULL, discovery = TRUE, 
     assignDist = TRUE, quant = TRUE, stranded = FALSE,  ncore = 1, yieldSize = NULL,  
-    trackReads = FALSE, returnDistTable = FALSE,
+    trackReads = FALSE, returnDistTable = FALSE, lowMemory = FALSE,
     fusionMode = FALSE, verbose = FALSE, demultiplexed = FALSE, spatial = NULL, quantData = NULL,
     sampleNames = NULL, cleanReads = FALSE, dedupUMI = FALSE, barcodesToFilter = NULL, clusters = NULL,
     processByChromosome = FALSE, processByBam = TRUE) {
@@ -165,6 +165,8 @@ bambu <- function(reads, annotations = NULL, genome = NULL, NDR = NULL,
             returnDistTable <- TRUE
         }
     }
+    if(lowMemory)
+        message("lowMemory has been deprecated and split into processByChromosome and processByBam. Please see Documentation")
     if(is.null(annotations)){ 
         annotations <- GRangesList()
     } else {

--- a/R/bambu.R
+++ b/R/bambu.R
@@ -138,7 +138,7 @@
 bambu <- function(reads, annotations = NULL, genome = NULL, NDR = NULL,
     mode = NULL, opt.discovery = NULL, opt.em = NULL, rcOutDir = NULL, discovery = TRUE, 
     assignDist = TRUE, quant = TRUE, stranded = FALSE,  ncore = 1, yieldSize = NULL,  
-    trackReads = FALSE, returnDistTable = FALSE, lowMemory = FALSE, 
+    trackReads = FALSE, returnDistTable = FALSE,
     fusionMode = FALSE, verbose = FALSE, demultiplexed = FALSE, spatial = NULL, quantData = NULL,
     sampleNames = NULL, cleanReads = FALSE, dedupUMI = FALSE, barcodesToFilter = NULL, clusters = NULL,
     processByChromosome = FALSE, processByBam = TRUE) {
@@ -165,9 +165,6 @@ bambu <- function(reads, annotations = NULL, genome = NULL, NDR = NULL,
             returnDistTable <- TRUE
         }
     }
-    if(lowMemory)
-        message("lowMemory has been deprecated and split into processByChromosome and processByBam. Please see Documentation")
-    
     if(is.null(annotations)){ 
         annotations <- GRangesList()
     } else {

--- a/README.md
+++ b/README.md
@@ -330,9 +330,9 @@ se <- bambu(reads = rcFiles, annotations = annotations, genome = fa.file)
 ```
 rcFiles can be generated in two ways, either as a direct output of the bambu() function when quant and discovery are FALSE, or as written outputs when a path is provided to the rcOutdir argument. When rcFiles are output using rcOutdir this is done using BiocFileCache. For more details on how to access, use, and identify these files see [here](https://bioconductor.org/packages/release/bioc/html/BiocFileCache.html). A short example is shown below.
 
-Example using rcOutDir to produce preprocessed files, and se returns to the path of files
+Example using rcOutDir to produce preprocessed files
 ```rscript
-se <- bambu(reads = test.bam, rcOutDir = "path/to/rcOutput/", annotations = annotations, genome = fa.file, assignDist = FALSE)
+se <- bambu(reads = test.bam, rcOutDir = "path/to/rcOutput/", annotations = annotations, genome = fa.file)
 ```
 
 This will store a preprocessed rcFile in the provided directory for each sample file provided to reads. To access these files for future use, we recommend using the BioCFileCache package which provides the metadata needed to identify the sample.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ se <- bambu(reads = rcFiles, annotations = annotations, genome = fa.file)
 ```
 rcFiles can be generated in two ways, either as a direct output of the bambu() function when quant and discovery are FALSE, or as written outputs when a path is provided to the rcOutdir argument. When rcFiles are output using rcOutdir this is done using BiocFileCache. For more details on how to access, use, and identify these files see [here](https://bioconductor.org/packages/release/bioc/html/BiocFileCache.html). A short example is shown below.
 
-Example using rcOutDir to produce preprocessed files
+Example using rcOutDir to produce preprocessed files, and se returns to the path of files
 ```rscript
 se <- bambu(reads = test.bam, rcOutDir = "path/to/rcOutput/", annotations = annotations, genome = fa.file, assignDist = FALSE)
 ```

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ rcFiles can be generated in two ways, either as a direct output of the bambu() f
 
 Example using rcOutDir to produce preprocessed files
 ```rscript
-se <- bambu(reads = test.bam, rcOutDir = "path/to/rcOutput/", annotations = annotations, genome = fa.file)
+se <- bambu(reads = test.bam, rcOutDir = "path/to/rcOutput/", annotations = annotations, genome = fa.file, assignDist = FALSE)
 ```
 
 This will store a preprocessed rcFile in the provided directory for each sample file provided to reads. To access these files for future use, we recommend using the BioCFileCache package which provides the metadata needed to identify the sample.
@@ -352,7 +352,7 @@ se <- bambu(reads = info$rpath[1], annotations = annotations, genome = fa.file)
 
 This output is also generated when both quant and discovery are set to false in a list form indexed by sample.
 ```rscript
-se <- bambu(reads = test.bam, annotations = annotations, genome = fa.file, discovery = FALSE, quant = FALSE)
+se <- bambu(reads = test.bam, annotations = annotations, genome = fa.file, discovery = FALSE, quant = FALSE, assignDist = FALSE)
 ```
 
 As this is an intermediate object it will not be suitable to use for general use cases. We will document the object below for any potential advanced use cases that may arise.


### PR DESCRIPTION
lowMemory causes error when specifying rcOutDir
update examples in readme about generate rcf (assignDist need to be FALSE when generating rcf)
