### PR TITLE
debugging the case when nonuniqueCounts is NULL

### DIFF
--- a/R/bambu-assignDist.R
+++ b/R/bambu-assignDist.R
@@ -103,6 +103,8 @@ generateNonUniqueCounts <- function(readClassDt, countMatrix, annotations){
     genes <- levels(factor(unique(mcols(annotations)$GENEID)))
     geneMat <- sparseMatrix(length(genes), ncol(nonuniqueCounts), x = 0)
     rownames(geneMat) <- genes
-    geneMat[rownames(nonuniqueCounts),] <- nonuniqueCounts
+    if(!is.null(rownames(nonuniqueCounts))){
+      geneMat[rownames(nonuniqueCounts),] <- nonuniqueCounts
+    }
     return(geneMat)
 }


### PR DESCRIPTION
When nonuniqueCounts is NULL, skip assigning it to geneMat.
A small bug occurs when handling simulated datasets that do not contain nonuniqueCounts.