### PR TITLE
Fix the cell cluster retrieval bug 

### DIFF
--- a/R/bambu.R
+++ b/R/bambu.R
@@ -284,11 +284,7 @@ bambu <- function(reads, annotations = NULL, genome = NULL, NDR = NULL,
                 iter <- clustering
                 
               } else{ #if clusters is a list
-                if(length(quantData)>1){
-                  iter <- clusters[[i]] #lowMemory mode
-                }else{
-                  iter <- clusters#do.call(c,clusters)
-                }
+                iter <- clusters[[i]]
               }
             }
             countsSeCompressed <- bplapply(iter, FUN = function(j){ # previous i changed to j to avoid duplicated assignment 


### PR DESCRIPTION
- regardless of the number of samples (i.e. number of quantData), the `clusters` will always be a sample list containing cell clusters for all samples
- this is to fix the bug mentioned in GoekeLab/bambu-singlecell-spatial#14