### PR TITLE
Switching from summarise() to reframe() to avoid dplyr warnings for v4. 

### DIFF
--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -304,23 +304,14 @@ makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
         } , BPPARAM = bpParameters))
     newUnsplicedTibble <- newUnsplicedTibble %>% 
         left_join(rowDataCombined, by =  "row_id") %>%
-        separate(row_id, c("sample","rcName"), sep = "\\-") %>%
-        mutate(sample_id = as.integer(gsub("s","",sample))) %>%
-        mutate(sample_name = colDataNames[sample_id]) %>%
-        select(-sample, -sample_id) %>%
         mutate(readCount_tmp = readCount) %>%
-        group_by(chr,strand, start, end, sample_name) %>%
+        group_by(chr,strand, start, end) %>%
         summarise(readCount = sum(readCount),
-                    geneReadProp = sum(geneReadProp),
-                    txScore = weighted.mean(txScore, readCount_tmp),
-                    txScore.noFit = weighted.mean(txScore.noFit, readCount_tmp)) %>%
-        group_by(chr, strand, start, end) %>% 
-        mutate(readCount = sum(readCount),
-                    maxTxScore = txScore,
-                    maxTxScore.noFit = txScore.noFit,
-                    NSampleReadCount = sum(readCount >= min.readCount), 
-                    NSampleReadProp = sum(geneReadProp >= 
-                                            min.readFractionByGene),
-                    NSampleTxScore = sum(maxTxScore > min.txScore.singleExon))
+                  maxTxScore = weighted.mean(txScore, readCount_tmp),
+                  maxTxScore.noFit = weighted.mean(txScore.noFit, readCount_tmp),
+                  NSampleReadCount = sum(readCount_tmp >= min.readCount), 
+                  NSampleReadProp = sum(geneReadProp >= 
+                                          min.readFractionByGene),
+                  NSampleTxScore = sum(txScore > min.txScore.singleExon))
     return(newUnsplicedTibble)
 }

--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -315,7 +315,7 @@ makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
                     txScore = weighted.mean(txScore, readCount_tmp),
                     txScore.noFit = weighted.mean(txScore.noFit, readCount_tmp)) %>%
         group_by(chr, strand, start, end) %>% 
-        summarise(readCount = sum(readCount),
+        mutate(readCount = sum(readCount),
                     maxTxScore = txScore,
                     maxTxScore.noFit = txScore.noFit,
                     NSampleReadCount = sum(readCount >= min.readCount), 


### PR DESCRIPTION
This pull is for fix the duplicate single-exon transcripts in final output and also the dplyr warning.
