### PR TITLE
Switching from summarise() to reframe() to avoid dplyr warnings

### DIFF
--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -300,23 +300,15 @@ makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
         } , BPPARAM = bpParameters))
     newUnsplicedTibble <- newUnsplicedTibble %>% 
         left_join(rowDataCombined, by =  "row_id") %>%
-        separate(row_id, c("sample","rcName"), sep = "\\-") %>%
-        mutate(sample_id = as.integer(gsub("s","",sample))) %>%
-        mutate(sample_name = colDataNames[sample_id]) %>%
-        select(-sample, -sample_id) %>%
         mutate(readCount_tmp = readCount) %>%
-        group_by(chr,strand, start, end, sample_name) %>%
+        group_by(chr,strand, start, end) %>%
         summarise(readCount = sum(readCount),
-                    geneReadProp = sum(geneReadProp),
-                    txScore = weighted.mean(txScore, readCount_tmp),
-                    txScore.noFit = weighted.mean(txScore.noFit, readCount_tmp)) %>%
-        group_by(chr, strand, start, end) %>% 
-        mutate(readCount = sum(readCount),
-                    maxTxScore = txScore,
-                    maxTxScore.noFit = txScore.noFit,
-                    NSampleReadCount = sum(readCount >= min.readCount), 
-                    NSampleReadProp = sum(geneReadProp >= 
-                                            min.readFractionByGene),
-                    NSampleTxScore = sum(maxTxScore > min.txScore.singleExon))
+                  maxTxScore = weighted.mean(txScore, readCount_tmp),
+                  maxTxScore.noFit = weighted.mean(txScore.noFit, readCount_tmp),
+                  NSampleReadCount = sum(readCount_tmp >= min.readCount), 
+                  NSampleReadProp = sum(geneReadProp >= 
+                                          min.readFractionByGene),
+                  NSampleTxScore = sum(txScore > min.txScore.singleExon))
+    
     return(newUnsplicedTibble)
 }

--- a/R/bambu-extendAnnotations-utilityCombine.R
+++ b/R/bambu-extendAnnotations-utilityCombine.R
@@ -311,7 +311,7 @@ makeUnsplicedTibble <- function(combinedNewUnsplicedSe,newUnsplicedSeList,
                     txScore = weighted.mean(txScore, readCount_tmp),
                     txScore.noFit = weighted.mean(txScore.noFit, readCount_tmp)) %>%
         group_by(chr, strand, start, end) %>% 
-        summarise(readCount = sum(readCount),
+        mutate(readCount = sum(readCount),
                     maxTxScore = txScore,
                     maxTxScore.noFit = txScore.noFit,
                     NSampleReadCount = sum(readCount >= min.readCount), 


### PR DESCRIPTION
This pull is for fix the duplicate single-exon transcripts in final output and also the dplyr warning.

1. The bug is actually we will have duplicate single-exon transcripts in the final se object. This occurred because read classes were being grouped by sample_name, preventing the merging of identical transcripts found across different samples.

1. I made these 2 changes
- Removed group_by(sample_name) to allow for global aggregation of read classes.
- Switched to readCount_tmp in the NSampleReadCount calculation, make sure we use the original per-sample read counts when validating read class against the min.readCount threshold 
