### PR TITLE
fix xgboost data and label rename to x and y warning

### DIFF
--- a/R/bambu-processReads_utilityJunctionErrorCorrection.R
+++ b/R/bambu-processReads_utilityJunctionErrorCorrection.R
@@ -210,8 +210,8 @@ fitXGBoostModel <- function(labels.train, data.train, nrounds = 50,
         data.train.cv.test <- data.train[-mySample,]
         labels.train.cv.test <- labels.train[-mySample]
         
-        cv.fit <- xgboost(data = data.train.cv, 
-            label = labels.train.cv, nthread = 1, nrounds = nrounds, 
+        cv.fit <- xgboost(x = data.train.cv, 
+            y = labels.train.cv, nthread = 1, nrounds = nrounds, 
             objective = "binary:logistic", 
             eval_metric = 'error',
             verbose = 0)

--- a/R/bambu-processReads_utilityJunctionErrorCorrection.R
+++ b/R/bambu-processReads_utilityJunctionErrorCorrection.R
@@ -213,8 +213,7 @@ fitXGBoostModel <- function(labels.train, data.train, nrounds = 50,
         cv.fit <- xgboost(x = data.train.cv, 
             y = labels.train.cv, nthread = 1, nrounds = nrounds, 
             objective = "binary:logistic", 
-            eval_metric = 'error',
-            verbose = 0)
+            eval_metric = 'error')
         predictions <- predict(cv.fit, data.train.cv.test)
         message('prediction accuracy (CV) (higher for splice ',
                 'donor than splice acceptor)')
@@ -228,11 +227,10 @@ fitXGBoostModel <- function(labels.train, data.train, nrounds = 50,
         message("AUC: ", evaluatePerformance(labels.train.cv.test == 1,predictions)$AUC)
     }
     
-    cv.fit <- xgboost(data = data.train, 
-                      label = labels.train, nthread=1, nrounds=nrounds, 
+    cv.fit <- xgboost(x = data.train, 
+                      y = labels.train, nthread=1, nrounds=nrounds, 
                       objective = "binary:logistic", 
-                      eval_metric='error',
-                      verbose = 0)
+                      eval_metric='error')
     
     return(cv.fit)
 }


### PR DESCRIPTION
Fix the warning related to xgboost argument updates from data and label to x and y 