### PR TITLE
Fix: Type instability in eqClassById during full_join in addEmptyRC

### DIFF
--- a/R/bambu-quantify_utilityFunctions.R
+++ b/R/bambu-quantify_utilityFunctions.R
@@ -117,6 +117,7 @@ getUniCountPerEquiRC <- function(distTable){
                             max(firstExonWidth))) %>%
     select(eqClassById,GENEID,nobs,rcWidth) %>% #eqClassByIdTemp,
     ungroup()  %>%
+    mutate(eqClassById = if (is.list(eqClassById)) eqClassById else as.list(eqClassById)) %>%
     distinct()
   return(eqClassCount)
 }


### PR DESCRIPTION
Fixes a `BiocParallel` error (specifically a `dplyr::full_join` incompatible types error) that occurs when a `eqClassCount` have only one row.

The column `eqClassById` is normally a list-column, but when there is only one row in the tibble, it gets simplified in to a atomic integer vector, making it incompatible to `full_join` with the `minEquiRC` tibble:
```
Tracing addEmptyRC(eqClassCount, annotations) on entry
Called from: eval(expr, p) 
 Browse[1]> eqClassCount
# A tibble: 1 × 4
  eqClassById GENEID                 nobs rcWidth
        <int> <chr>                 <int>   <int>
1          -2 ENSMUSG00000025290.17     1     514 
```
```
 Error: BiocParallel errors
  1 remote errors, element index: 2
  2 unevaluated and other errors
  first remote error:
Error in full_join(eqClassCount, minEquiRC, by = c("eqClassById", "GENEID", : Can't join `x$eqClassById` with `y$eqClassById` due to incompatible types. 
```

Added a line to force it into a list column.