### PR TITLE
Fix xgboost parallel processing issue

### DIFF
--- a/R/bambu.R
+++ b/R/bambu.R
@@ -149,7 +149,7 @@ bambu <- function(reads, annotations = NULL, genome = NULL, NDR = NULL,
     
     emParameters <- setEmParameters(emParameters = opt.em)
     bpParameters <- setBiocParallelParameters(reads, ncore, verbose)
-
+    xgb.set.config(nthread = 1)
     rm.readClassSe <- FALSE
     readClassList = reads
     isRDSs = all(sapply(reads, class)=="RangedSummarizedExperiment")

--- a/R/bambu_utilityFunctions.R
+++ b/R/bambu_utilityFunctions.R
@@ -4,9 +4,6 @@
 #' @importFrom BiocParallel bpparam
 #' @noRd
 setBiocParallelParameters <- function(reads, ncore, verbose){
-    if(ncore >= 2) message("WARNING - If you change the number of cores (ncore) ",
-    "between Bambu runs and there is no progress please restart your R session ",
-    "to resolve the issue that originates from the XGboost package.")
     bpParameters <- bpparam()
     #===# set parallel options: otherwise use parallel to distribute samples
     bpParameters$workers <- ifelse(length(reads) == 1, 1, ncore)

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Minor changes:
 - Resolve process.y.margin.and.object error [issue](https://github.com/GoekeLab/bambu/issues/505)  
 - Resolve xgboost warnings related to argument updates in the recent xgboost version
 - Resolve the dplyr warning related to summarise usage [issue](https://github.com/GoekeLab/bambu/issues/380) 
+- Resolve the xgboost related parallel processing restarting with no progress issue 
 
 
 **bambu v3.8.2**


### PR DESCRIPTION
Fix the parallel processing issue with xgboost 
Now rurun bambu with the same R session with multiple cores will not cause hanging issue any more 